### PR TITLE
Test: Refresh and Whoami

### DIFF
--- a/api/controllers/session_test.go
+++ b/api/controllers/session_test.go
@@ -15,6 +15,37 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
+// ## Helper functions
+
+// loginWithRandomUser creates a random user, inserts it into the database, verifies it and tries to login with it
+func loginWithRandomUser() (interfaces.User, map[string]string) {
+	ctx := context.Background()
+
+	// Create a random user
+	randomUser := tests.GenerateRandomUser()
+	router := tests.SetupGinRouter()
+	tests.InsertUser(randomUser, router, HandleSignUp)
+
+	// Verify the user and save the database document
+	var databaseUser interfaces.User
+	usersCollection.UpdateOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}}, bson.D{{Key: "$set", Value: bson.D{{Key: "isVerified", Value: true}}}})
+	usersCollection.FindOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}}).Decode(&databaseUser)
+
+	// Try to login with the random user
+	var response map[string]string
+	loginForm := map[string]string{
+		"email":    randomUser.Email,
+		"password": randomUser.Password,
+	}
+
+	router.POST("/login", HandleLogIn)
+	w, req := tests.SetupPostRequest("/login", loginForm)
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	return databaseUser, response
+}
+
 // TestSignupSuccess tests the signup endpoint with a non verified user
 func TestLoginForbidden(t *testing.T) {
 	c := require.New(t)

--- a/api/controllers/session_test.go
+++ b/api/controllers/session_test.go
@@ -203,3 +203,20 @@ func TestRefreshSuccess(t *testing.T) {
 	// Remove the user from the database
 	usersCollection.DeleteOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}})
 }
+
+// TestWhoamiUnauthorized tests the whoami endpoint without a valid access token
+func TestWhoamiUnauthorized(t *testing.T) {
+	c := require.New(t)
+	router := tests.SetupGinRouter()
+
+	// Try to get the user without a valid access token
+	var whoamiResponse map[string]string
+	router.GET("/whoami", middlewares.MustProvideAccessToken(), HandleWhoami)
+	w, req := tests.SetupGetRequest("/whoami")
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &whoamiResponse)
+
+	// Check if the response is correct
+	c.Equal(http.StatusUnauthorized, w.Code)
+	c.Equal("Access token is required", whoamiResponse["message"])
+}

--- a/api/controllers/session_test.go
+++ b/api/controllers/session_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/PedroChaparro/loomies-backend/configuration"
 	"github.com/PedroChaparro/loomies-backend/interfaces"
+	"github.com/PedroChaparro/loomies-backend/middlewares"
 	"github.com/PedroChaparro/loomies-backend/tests"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/require"
@@ -97,5 +98,58 @@ func TestLoginSuccess(t *testing.T) {
 	c.Equal(databaseUser.Id.Hex(), refreshTokenClaims["userid"])
 
 	// Delete the user from the database
+	usersCollection.DeleteOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}})
+}
+
+// TestRefreshSuccess tests the refresh endpoint with a valid refresh token
+func TestRefreshSuccess(t *testing.T) {
+	c := require.New(t)
+	ctx := context.Background()
+	defer ctx.Done()
+
+	// Create a random user
+	randomUser := tests.GenerateRandomUser()
+	router := tests.SetupGinRouter()
+	tests.InsertUser(randomUser, router, HandleSignUp)
+
+	// Verify the user and save the database document
+	usersCollection.UpdateOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}}, bson.D{{Key: "$set", Value: bson.D{{Key: "isVerified", Value: true}}}})
+	var databaseUser interfaces.User
+	usersCollection.FindOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}}).Decode(&databaseUser)
+
+	// Login with the random user
+	var loginResponse map[string]interface{}
+	loginForm := map[string]string{
+		"email":    randomUser.Email,
+		"password": randomUser.Password,
+	}
+
+	router.POST("/login", HandleLogIn)
+	w, req := tests.SetupPostRequest("/login", loginForm)
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &loginResponse)
+
+	// Get a new access token from the refresh token
+	var refreshResponse map[string]string
+	router.POST("/refresh", middlewares.MustProvideRefreshToken(), HandleRefresh)
+	w, req = tests.SetupPostRequest("/refresh", nil, tests.CustomHeader{Name: "Refresh-Token", Value: loginResponse["refreshToken"].(string)})
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &refreshResponse)
+
+	// 1. Check if the response fields are correct
+	c.Equal(http.StatusOK, w.Code)
+	c.NotEmpty(refreshResponse["accessToken"])
+	c.Equal("Successfully refreshed access token", refreshResponse["message"])
+
+	// 2. Check tokens claims
+	accessTokenClaims := jwt.MapClaims{}
+	_, err := jwt.ParseWithClaims(refreshResponse["accessToken"], accessTokenClaims, func(token *jwt.Token) (interface{}, error) {
+		return []byte(configuration.GetAccessTokenSecret()), nil
+	})
+
+	c.NoError(err)
+	c.Equal(databaseUser.Id.Hex(), accessTokenClaims["userid"])
+
+	// Remove the user from the database
 	usersCollection.DeleteOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}})
 }

--- a/api/tests/tests_utils.go
+++ b/api/tests/tests_utils.go
@@ -26,10 +26,26 @@ func SetupGinRouter() *gin.Engine {
 	return router
 }
 
-// SetupPostRequest creates a new POST request with the given payload
+// SetupPostRequest creates a new POST request with the given payload and headers (if any)
 func SetupPostRequest(endpoint string, payload interface{}, headers ...CustomHeader) (*httptest.ResponseRecorder, *http.Request) {
 	payloadBytes, _ := json.Marshal(payload)
 	req, _ := http.NewRequest("POST", endpoint, bytes.NewReader(payloadBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Set the custom headers
+	if len(headers) > 0 {
+		for _, header := range headers {
+			req.Header.Set(header.Name, header.Value)
+		}
+	}
+
+	w := httptest.NewRecorder()
+	return w, req
+}
+
+// SetupGetRequest creates a new GET request with the given headers (if any)
+func SetupGetRequest(endpoint string, headers ...CustomHeader) (*httptest.ResponseRecorder, *http.Request) {
+	req, _ := http.NewRequest("GET", endpoint, nil)
 	req.Header.Set("Content-Type", "application/json")
 
 	// Set the custom headers

--- a/api/tests/tests_utils.go
+++ b/api/tests/tests_utils.go
@@ -11,6 +11,12 @@ import (
 	"github.com/jaswdr/faker"
 )
 
+// ### Types / Structs
+type CustomHeader struct {
+	Name  string
+	Value string
+}
+
 // Fake: faker instance to generate random data
 var FakerInstance = faker.New()
 
@@ -21,10 +27,18 @@ func SetupGinRouter() *gin.Engine {
 }
 
 // SetupPostRequest creates a new POST request with the given payload
-func SetupPostRequest(endpoint string, payload interface{}) (*httptest.ResponseRecorder, *http.Request) {
+func SetupPostRequest(endpoint string, payload interface{}, headers ...CustomHeader) (*httptest.ResponseRecorder, *http.Request) {
 	payloadBytes, _ := json.Marshal(payload)
 	req, _ := http.NewRequest("POST", endpoint, bytes.NewReader(payloadBytes))
 	req.Header.Set("Content-Type", "application/json")
+
+	// Set the custom headers
+	if len(headers) > 0 {
+		for _, header := range headers {
+			req.Header.Set(header.Name, header.Value)
+		}
+	}
+
 	w := httptest.NewRecorder()
 	return w, req
 }


### PR DESCRIPTION
- Add some test to the /refresh and /whoami endpoints. 
- Current coverage (session.go): 52.1%.
- Current coverage (user.go): 57.4%.