### PR TITLE
Fix: Outlier Gym

### DIFF
--- a/data/places.json
+++ b/data/places.json
@@ -228,10 +228,10 @@
     "longitude": -73.0378490480672
   },
   {
-    "name": "Peaje Los Curos",
+    "name": "Central Trunk Gym",
     "zoneIdentifier": "fd1c7230-c864-43ed-8e4e-bc18a1566f8f",
-    "latitude": 6.8256304,
-    "longitude": -72.9993606
+    "latitude": 6.96,
+    "longitude": -73.035
   },
   {
     "name": "Romaguera Dale",


### PR DESCRIPTION
Depends on #61.

The problem: 

![image](https://user-images.githubusercontent.com/62714297/224143126-34637098-0792-4aa4-9393-981ae50ad0a2.png)

That was solved by updating the gym coordinates to a new ones within the zone frontiers and changing the Gym name to a "random" one. 