### PR TITLE
Feat: Default gyms "protectors"

### DIFF
--- a/algorithms/database/bulk.js
+++ b/algorithms/database/bulk.js
@@ -6,6 +6,7 @@ import {
   LoomieTypeModel,
   LoomieRarityModel,
   BaseLoomieModel,
+  CaughtLoomieModel,
   ItemModel,
   LoomBallModel,
 } from "./models/mongoose.js";
@@ -28,71 +29,11 @@ const loomballs = readJsonFromDataFolder("loomballs");
 // Global variables
 const globalLoomiesTypesIds = [];
 const globalLoomiesRaritiesIds = [];
+let insertedBaseLoomies;
 
-// --- Zones and Gyms ---
-console.log("🏟️ Inserting gyms and zones...");
-const coordinates = { x: 0, y: 0 };
-let currentLongitude;
-
-console.log("Expected zones: ", zones.length);
-console.log("Expected gyms: ", gyms.length);
-
-for await (const zone of zones) {
-  let GymMongoId;
-
-  // Initialize currentLongitude
-  if (!currentLongitude) currentLongitude = zone.bottomFrontier;
-
-  // Increment coordinates when longitude changes (New row)
-  if (currentLongitude !== zone.bottomFrontier) {
-    currentLongitude = zone.bottomFrontier;
-    coordinates.x = 0;
-    coordinates.y++;
-  }
-
-  // Get the zone's gym
-  const gym = gyms.findIndex((gym) => gym.zoneIdentifier === zone.identifier);
-
-  // Insert the gym into mongodb and get the id
-  if (gym !== -1) {
-    const { name, latitude, longitude } = gyms[gym];
-    const newGym = new GymModel({
-      name,
-      latitude,
-      longitude,
-      // Initially the gym has no owner
-      owner: null,
-      // Initially the gym has no rewards until the cronjob runs
-      current_rewards: [],
-      rewards_claimed_by: [],
-    });
-    const { _id } = await newGym.save();
-    GymMongoId = _id;
-  }
-
-  // Insert zone with the gym id
-  const { leftFrontier, rightFrontier, topFrontier, bottomFrontier, number } =
-    zone;
-
-  const newZone = new ZoneModel({
-    leftFrontier,
-    rightFrontier,
-    topFrontier,
-    bottomFrontier,
-    number,
-    coordinates: `${coordinates.x},${coordinates.y}`,
-    gym: GymMongoId ? GymMongoId : null,
-    loomies: [], // Empty loomies array
-  });
-
-  await newZone.save();
-
-  // Increment coordinates
-  coordinates.x++;
-}
-
-console.log("Zones inserted: ", await ZoneModel.countDocuments());
-console.log("Gyms inserted: ", await GymModel.countDocuments(), "\n");
+// --- Loomies data ---
+// It's necessary to insert the loomies data beforte the zones and gyms
+// because the gyms will have a reference to the loomies
 
 // --- Loomies types ---
 console.log("✨ Inserting loomie types...");
@@ -227,7 +168,78 @@ for await (const loomie of loomies) {
   await newLoomie.save();
 }
 
+// Get the inserted loomies to create the default loomie team for each gym
+insertedBaseLoomies = await BaseLoomieModel.find();
 console.log("Inserted loomies: ", await BaseLoomieModel.countDocuments(), "\n");
+
+// --- Zones and Gyms ---
+console.log("🏟️ Inserting gyms and zones...");
+const coordinates = { x: 0, y: 0 };
+let currentLongitude;
+
+console.log("Expected zones: ", zones.length);
+console.log("Expected gyms: ", gyms.length);
+
+for await (const zone of zones) {
+  let GymMongoId;
+
+  // Initialize currentLongitude
+  if (!currentLongitude) currentLongitude = zone.bottomFrontier;
+
+  // Increment coordinates when longitude changes (New row)
+  if (currentLongitude !== zone.bottomFrontier) {
+    currentLongitude = zone.bottomFrontier;
+    coordinates.x = 0;
+    coordinates.y++;
+  }
+
+  // Get the zone's gym
+  const gym = gyms.findIndex((gym) => gym.zoneIdentifier === zone.identifier);
+
+  // Insert the gym into mongodb and get the id
+  if (gym !== -1) {
+    const { name, latitude, longitude } = gyms[gym];
+
+    // TODO: Create a random loomie team to protect the gym
+
+    const newGym = new GymModel({
+      name,
+      latitude,
+      longitude,
+      // Initially the gym has no owner
+      owner: null,
+      // Initially the gym has no rewards until the cronjob runs
+      current_rewards: [],
+      rewards_claimed_by: [],
+    });
+
+    const { _id } = await newGym.save();
+    GymMongoId = _id;
+  }
+
+  // Insert zone with the gym id
+  const { leftFrontier, rightFrontier, topFrontier, bottomFrontier, number } =
+    zone;
+
+  const newZone = new ZoneModel({
+    leftFrontier,
+    rightFrontier,
+    topFrontier,
+    bottomFrontier,
+    number,
+    coordinates: `${coordinates.x},${coordinates.y}`,
+    gym: GymMongoId ? GymMongoId : null,
+    loomies: [], // Empty loomies array
+  });
+
+  await newZone.save();
+
+  // Increment coordinates
+  coordinates.x++;
+}
+
+console.log("Zones inserted: ", await ZoneModel.countDocuments());
+console.log("Gyms inserted: ", await GymModel.countDocuments(), "\n");
 
 // --- Items ---
 console.log("📦 Inserting items...");

--- a/algorithms/database/models/mongoose.js
+++ b/algorithms/database/models/mongoose.js
@@ -45,6 +45,7 @@ const GymSchema = new Schema(
     longitude: Number,
     name: String,
     owner: { type: Schema.Types.ObjectId, ref: "users" },
+    protectors: [{ type: Schema.Types.ObjectId, ref: "caught_loomies" }],
     current_players_rewards: sharedRewardSchema,
     current_owners_rewards: sharedRewardSchema,
     rewards_claimed_by: [{ type: Schema.Types.ObjectId, ref: "users" }],

--- a/algorithms/database/models/mongoose.js
+++ b/algorithms/database/models/mongoose.js
@@ -122,12 +122,15 @@ const WildLoomieSchema = new Schema(
   { versionKey: false }
 );
 
-const CaughtLoomieSchema = new Schema({
-  // The caught loomie is a copy of the wild loomie
-  ...sharedLoomieAttributes,
-  // But also has a reference to the user that caught it
-  owner: { type: Schema.Types.ObjectId, ref: "users" },
-});
+const CaughtLoomieSchema = new Schema(
+  {
+    // The caught loomie is a copy of the wild loomie
+    ...sharedLoomieAttributes,
+    // But also has a reference to the user that caught it
+    owner: { type: Schema.Types.ObjectId, ref: "users" },
+  },
+  { versionKey: false }
+);
 
 const ItemsSchema = new Schema(
   {

--- a/algorithms/database/models/mongoose.js
+++ b/algorithms/database/models/mongoose.js
@@ -19,46 +19,33 @@ const ZoneSchema = new Schema(
 ZoneSchema.set("autoIndex", false);
 ZoneSchema.index({ coordinates: "hashed" });
 
+// Create a schema for the rewards that can be claimed by players and gym owners
+const sharedRewardSchema = {
+  type: [
+    {
+      reward_collection: {
+        type: String,
+        // Gym rewards can be items or loomballs
+        enum: ["items", "loom_balls"],
+      },
+      reward_id: {
+        type: Schema.Types.ObjectId,
+        // Dynamically reference the correct collection
+        refPath: "current_rewards.reward_type",
+      },
+      reward_quantity: Number,
+    },
+  ],
+};
+
 const GymSchema = new Schema(
   {
     latitude: Number,
     longitude: Number,
     name: String,
     owner: { type: Schema.Types.ObjectId, ref: "users" },
-    current_players_rewards: {
-      type: [
-        {
-          reward_collection: {
-            type: String,
-            // Gym rewards can be items or loomballs
-            enum: ["items", "loom_balls"],
-          },
-          reward_id: {
-            type: Schema.Types.ObjectId,
-            // Dynamically reference the correct collection
-            refPath: "current_rewards.reward_type",
-          },
-          reward_quantity: Number,
-        },
-      ],
-    },
-    current_owners_rewards: {
-      type: [
-        {
-          reward_collection: {
-            type: String,
-            // Gym rewards can be items or loomballs
-            enum: ["items", "loom_balls"],
-          },
-          reward_id: {
-            type: Schema.Types.ObjectId,
-            // Dynamically reference the correct collection
-            refPath: "current_rewards.reward_type",
-          },
-          reward_quantity: Number,
-        },
-      ],
-    },
+    current_players_rewards: sharedRewardSchema,
+    current_owners_rewards: sharedRewardSchema,
     rewards_claimed_by: [{ type: Schema.Types.ObjectId, ref: "users" }],
   },
   { versionKey: false }

--- a/algorithms/database/models/mongoose.js
+++ b/algorithms/database/models/mongoose.js
@@ -1,5 +1,6 @@
 import { Schema, model } from "mongoose";
 
+// -- --- --- --- ---
 // Schemas
 const ZoneSchema = new Schema(
   {
@@ -91,21 +92,25 @@ const BaseLoomieSchema = new Schema(
   { versionKey: false }
 );
 
+const sharedLoomieAttributes = {
+  serial: Number,
+  name: String,
+  types: {
+    type: [Schema.Types.ObjectId],
+    ref: "loomie_types",
+  },
+  rarity: {
+    type: Schema.Types.ObjectId,
+    ref: "loomie_rarities",
+  },
+  hp: Number,
+  attack: Number,
+  defense: Number,
+};
+
 const WildLoomieSchema = new Schema(
   {
-    serial: Number,
-    name: String,
-    types: {
-      type: [Schema.Types.ObjectId],
-      ref: "loomie_types",
-    },
-    rarity: {
-      type: Schema.Types.ObjectId,
-      ref: "loomie_rarities",
-    },
-    hp: Number,
-    attack: Number,
-    defense: Number,
+    ...sharedLoomieAttributes,
     zone_id: {
       type: Schema.Types.ObjectId,
       ref: "zones",
@@ -116,6 +121,13 @@ const WildLoomieSchema = new Schema(
   },
   { versionKey: false }
 );
+
+const CaughtLoomieSchema = new Schema({
+  // The caught loomie is a copy of the wild loomie
+  ...sharedLoomieAttributes,
+  // But also has a reference to the user that caught it
+  owner: { type: Schema.Types.ObjectId, ref: "users" },
+});
 
 const ItemsSchema = new Schema(
   {
@@ -170,12 +182,18 @@ const LoomBallsSchema = new Schema(
   { versionKey: false }
 );
 
+// -- --- --- --- ---
 // Models
+
+// Zone & Gyms
 export const ZoneModel = model("zones", ZoneSchema);
 export const GymModel = model("gyms", GymSchema);
+// Loomies
 export const LoomieTypeModel = model("loomie_types", LoomieTypeSchema);
 export const LoomieRarityModel = model("loomie_rarities", LoomieRaritySchema);
 export const BaseLoomieModel = model("base_loomies", BaseLoomieSchema);
 export const WildLoomieModel = model("wild_loomies", WildLoomieSchema);
+export const CaughtLoomieModel = model("caught_loomies", CaughtLoomieSchema);
+// Collectionables
 export const ItemModel = model("items", ItemsSchema);
 export const LoomBallModel = model("loom_balls", LoomBallsSchema);

--- a/algorithms/database/models/mongoose.js
+++ b/algorithms/database/models/mongoose.js
@@ -127,6 +127,8 @@ const CaughtLoomieSchema = new Schema(
   {
     // The caught loomie is a copy of the wild loomie
     ...sharedLoomieAttributes,
+    // The caught loomie can be busy if it's
+    is_busy: Boolean,
     // But also has a reference to the user that caught it
     owner: { type: Schema.Types.ObjectId, ref: "users" },
   },

--- a/algorithms/database/utils/utils.js
+++ b/algorithms/database/utils/utils.js
@@ -46,6 +46,8 @@ export async function createRandomLoomieTeam(commonLoomies) {
       defense: baseLoomie.base_defense - getRandomInt(0, 5),
       // The loomie has no owner, it just exists to protect the gym initially
       owner: null,
+      // The loomie is busy defending the gym althought it's not owned by anyone
+      is_busy: true,
     };
   });
 

--- a/algorithms/database/utils/utils.js
+++ b/algorithms/database/utils/utils.js
@@ -1,4 +1,9 @@
 import fs from "fs";
+import { CaughtLoomieModel, LoomieRarityModel } from "../models/mongoose.js";
+
+function getRandomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
 
 export function readJsonFromDataFolder(name) {
   const path = `../../data/${name}.json`;
@@ -10,4 +15,41 @@ export function readJsonFromDataFolder(name) {
     console.log(err);
     process.exit(1);
   }
+}
+
+/**
+ * Create a random team of 6 loomies to defend a gym
+ * @param {*} commonLoomies Array of loomies with rarity "common"
+ * @returns Array of the ids of the generated gym defenders
+ */
+export async function createRandomLoomieTeam(commonLoomies) {
+  const commonLoomiesCopy = [...commonLoomies];
+
+  let team = Array.from({ length: 6 }, () => {
+    // Select a random loomie
+    const randomIndex = Math.floor(Math.random() * commonLoomiesCopy.length);
+    return commonLoomiesCopy[randomIndex];
+  });
+
+  // Replace the base stats names
+  // (e.g. "base_attack" -> "attack")
+  team = team.map((baseLoomie) => {
+    return {
+      // Shared attributes
+      serial: baseLoomie.serial,
+      name: baseLoomie.name,
+      types: baseLoomie.types,
+      rarity: baseLoomie.rarity,
+      // Change names and reduce the stats to generate a weaker loomie
+      hp: baseLoomie.base_hp - getRandomInt(15, 20),
+      attack: baseLoomie.base_attack - getRandomInt(5, 10),
+      defense: baseLoomie.base_defense - getRandomInt(0, 5),
+      // The loomie has no owner, it just exists to protect the gym initially
+      owner: null,
+    };
+  });
+
+  const inserted = await CaughtLoomieModel.insertMany(team);
+  const insertedIds = inserted.map((loomie) => loomie._id);
+  return insertedIds;
 }

--- a/api/interfaces/interfaces.go
+++ b/api/interfaces/interfaces.go
@@ -175,6 +175,7 @@ type WildLoomie struct {
 
 type CaughtLoomie struct {
 	Owner   primitive.ObjectID   `json:"owner,omitempty"       bson:"owner,omitempty"`
+	IsBusy  bool                 `json:"is_busy"      bson:"is_busy"`
 	Id      primitive.ObjectID   `json:"_id,omitempty"       bson:"_id,omitempty"`
 	Serial  int                  `json:"serial"      bson:"serial"`
 	Name    string               `json:"name"      bson:"name"`

--- a/api/interfaces/interfaces.go
+++ b/api/interfaces/interfaces.go
@@ -171,3 +171,15 @@ type WildLoomie struct {
 	Longitude   float64              `json:"longitude"     bson:"longitude"`
 	GeneratedAt int64                `json:"generated_at"     bson:"generated_at"`
 }
+
+type CaughtLoomie struct {
+	Owner   primitive.ObjectID   `json:"owner,omitempty"       bson:"owner,omitempty"`
+	Id      primitive.ObjectID   `json:"_id,omitempty"       bson:"_id,omitempty"`
+	Serial  int                  `json:"serial"      bson:"serial"`
+	Name    string               `json:"name"      bson:"name"`
+	Types   []primitive.ObjectID `json:"types"     bson:"types"`
+	Rarity  primitive.ObjectID   `json:"rarity"     bson:"rarity"`
+	HP      int                  `json:"hp"     bson:"hp"`
+	Attack  int                  `json:"attack"     bson:"attack"`
+	Defense int                  `json:"defense"     bson:"defense"`
+}

--- a/api/interfaces/interfaces.go
+++ b/api/interfaces/interfaces.go
@@ -73,6 +73,7 @@ type Gym struct {
 	Longitude             float64              `json:"longitude"      bson:"longitude"`
 	Name                  string               `json:"name"      bson:"name"`
 	Owner                 primitive.ObjectID   `json:"owner,omitempty"      bson:"owner,omitempty"`
+	Protectors            []primitive.ObjectID `json:"protectors"      bson:"protectors"`
 	CurrentPlayersRewards []GymRewardItem      `json:"current_players_rewards"      bson:"current_players_rewards"`
 	CurrentOwnerRewards   []GymRewardItem      `json:"current_owners_rewards"      bson:"current_owners_rewards"`
 	RewardsClaimedBy      []primitive.ObjectID `json:"rewards_claimed_by"      bson:"rewards_claimed_by"`


### PR DESCRIPTION
## Includes 

- [x] Generate a random "loomie team" to initially "protect" all the generated gyms.

## How can I test It?

Just re-generate the database with the `pnpm bulk` command, yo should see the new `caught_loomies` collection and the `protectors` field on each gym.

Gym: 

![image](https://user-images.githubusercontent.com/62714297/224550563-90524ebc-c776-4a46-9c11-05ec093484dc.png)

Caught loomies collection: 

![image](https://user-images.githubusercontent.com/62714297/224550579-e1c54d87-0daf-4911-9d54-77d42400e99f.png)


## Notes

- As you can see, initially, nor gyms or cuaught_loomies has an owner, that's because when an user claims the gym, the caught_loomies can be safely deleted (THIS ONLY OCCUR THE FIRST TIME THE GYM IS CLAIMED BY SOME USER).