### PR TITLE
Endpoint to reset password

### DIFF
--- a/api/interfaces/interfaces.go
+++ b/api/interfaces/interfaces.go
@@ -118,6 +118,8 @@ type User struct {
 	Loomies                         []primitive.ObjectID `json:"loomies"   bson:"loomies"`
 	ValidationCode                  string               `json:"validationCode"  bson:"validationCode"`
 	ValidationCodeExp               int64                `json:"validationCodeExp"   bson:"validationCodeExp"`
+	ResetPassCode                   string               `json:"resetPassCode"  bson:"resetPassCode"`
+	ResetPassCodeExp                int64                `json:"resetPassCodeExp"   bson:"resetPassCodeExp"`
 	IsVerified                      bool                 `json:"isVerified"   bson:"isVerified"`
 	CurrentLoomiesGenerationTimeout int64                `json:"currentLoomiesGenerationTimeout"   bson:"currentLoomiesGenerationTimeout"`
 	LastLoomieGenerationTime        int64                `json:"lastLoomieGenerationTime"   bson:"lastLoomieGenerationTime"`
@@ -190,11 +192,11 @@ type ValidationCode struct {
 	ValidationCodeExp int64  `json:"validationCodeExp,omitempty"`
 }
 
-// todo
-type ValidationPassword struct {
-	ValidationCode string `json:"validationCode"`
-	Email          string `json:"email"`
-	Password       string `json:"password"  bson:"password"`
+type ResetPasswordCode struct {
+	ResetPassCode    string `json:"resetPassCode"`
+	ResetPassCodeExp int64  `json:"resetPassCodeExp,omitempty"`
+	Email            string `json:"email"`
+	Password         string `json:"password"  bson:"password"`
 }
 
 type CaughtLoomie struct {

--- a/api/interfaces/interfaces.go
+++ b/api/interfaces/interfaces.go
@@ -190,6 +190,13 @@ type ValidationCode struct {
 	ValidationCodeExp int64  `json:"validationCodeExp,omitempty"`
 }
 
+// todo
+type ValidationPassword struct {
+	ValidationCode string `json:"validationCode"`
+	Email          string `json:"email"`
+	Password       string `json:"password"  bson:"password"`
+}
+
 type CaughtLoomie struct {
 	Owner   primitive.ObjectID   `json:"owner,omitempty"       bson:"owner,omitempty"`
 	IsBusy  bool                 `json:"is_busy"      bson:"is_busy"`

--- a/api/models/user.go
+++ b/api/models/user.go
@@ -13,7 +13,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-var Collection *mongo.Collection = configuration.ConnectToMongoCollection("users")
+var UserCollection *mongo.Collection = configuration.ConnectToMongoCollection("users")
 
 func InsertUser(data interfaces.User) error {
 	// Set the current time as the "last time the user generated loomies"
@@ -24,7 +24,7 @@ func InsertUser(data interfaces.User) error {
 	data.Loomies = []primitive.ObjectID{}
 
 	//Insert User in database
-	_, err := Collection.InsertOne(context.TODO(), data)
+	_, err := UserCollection.InsertOne(context.TODO(), data)
 
 	return err
 }
@@ -54,7 +54,7 @@ func UpdatePasword(email string, p string) error {
 		{Key: "password", Value: p},
 	},
 	}}
-	_, err := Collection.UpdateOne(context.TODO(), filter, update)
+	_, err := UserCollection.UpdateOne(context.TODO(), filter, update)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -66,7 +66,7 @@ func GetUserByEmail(email string) (interfaces.User, error) {
 	var userE interfaces.User
 
 	// Find the user with the given email (case insensitive)
-	err := Collection.FindOne(
+	err := UserCollection.FindOne(
 		context.TODO(),
 		bson.M{"email": bson.M{"$regex": email, "$options": "i"}},
 	).Decode(&userE)
@@ -79,7 +79,7 @@ func GetUserByUsername(Username string) (interfaces.User, error) {
 	var userU interfaces.User
 
 	//Find the user with the given username (case insensitive)
-	err := Collection.FindOne(
+	err := UserCollection.FindOne(
 		context.TODO(),
 		bson.M{"username": bson.M{"$regex": Username, "$options": "i"}},
 	).Decode(&userU)
@@ -89,7 +89,7 @@ func GetUserByUsername(Username string) (interfaces.User, error) {
 
 func GetUserByEmailAndVerifStatus(email string) (interfaces.User, error) {
 	var userE interfaces.User
-	err := Collection.FindOne(
+	err := UserCollection.FindOne(
 		context.TODO(),
 		bson.D{{Key: "email", Value: email}, {Key: "isVerified", Value: true}},
 	).Decode(&userE)
@@ -105,7 +105,7 @@ func GetUserById(id string) (interfaces.User, error) {
 		return user, err
 	}
 
-	err = Collection.FindOne(
+	err = UserCollection.FindOne(
 		context.TODO(),
 		bson.D{{Key: "_id", Value: mongoid}},
 	).Decode(&user)
@@ -123,7 +123,7 @@ func UpdateUserGenerationTimes(userId string, lastGenerated int64, newTimeout in
 	}
 
 	// Update the user document
-	_, err = Collection.UpdateOne(
+	_, err = UserCollection.UpdateOne(
 		context.TODO(),
 		bson.D{{Key: "_id", Value: mongoid}},
 		bson.D{
@@ -141,7 +141,7 @@ func CheckCodeExistence(email string, code string) bool {
 
 	var usercode interfaces.ValidationCode
 	filter := bson.D{{Key: "email", Value: email}}
-	err := Collection.FindOne(context.TODO(), filter).Decode(&usercode)
+	err := UserCollection.FindOne(context.TODO(), filter).Decode(&usercode)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -153,7 +153,7 @@ func CheckCodeExistence(email string, code string) bool {
 			{Key: "validationCode", Value: nil},
 		},
 		}}
-		Collection.UpdateOne(context.TODO(), filter, update)
+		UserCollection.UpdateOne(context.TODO(), filter, update)
 		return false
 	}
 
@@ -169,7 +169,7 @@ func CheckCodeExistence(email string, code string) bool {
 			{Key: "validationCodeExp", Value: nil},
 		},
 		}}
-		Collection.UpdateOne(context.TODO(), filter, update)
+		UserCollection.UpdateOne(context.TODO(), filter, update)
 		return true
 	}
 }
@@ -178,7 +178,7 @@ func CheckResetPassCodeExistence(email string, code string) bool {
 
 	var usercode interfaces.ResetPasswordCode
 	filter := bson.D{{Key: "email", Value: email}}
-	err := Collection.FindOne(context.TODO(), filter).Decode(&usercode)
+	err := UserCollection.FindOne(context.TODO(), filter).Decode(&usercode)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -190,7 +190,7 @@ func CheckResetPassCodeExistence(email string, code string) bool {
 			{Key: "resetPassCode", Value: nil},
 		},
 		}}
-		Collection.UpdateOne(context.TODO(), filter, update)
+		UserCollection.UpdateOne(context.TODO(), filter, update)
 		return false
 	}
 
@@ -205,7 +205,7 @@ func CheckResetPassCodeExistence(email string, code string) bool {
 			{Key: "resetPassCodeExp", Value: nil},
 		},
 		}}
-		Collection.UpdateOne(context.TODO(), filter, update)
+		UserCollection.UpdateOne(context.TODO(), filter, update)
 		return true
 	}
 }
@@ -218,7 +218,7 @@ func UpdateCode(email string, validationCode string) error {
 		{Key: "validationCodeExp", Value: time.Now().Add(time.Minute * 15).Unix()},
 	},
 	}}
-	_, err := Collection.UpdateOne(context.TODO(), filter, update)
+	_, err := UserCollection.UpdateOne(context.TODO(), filter, update)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -234,7 +234,7 @@ func UpdateResetPassCode(email string, resetPassCode string) error {
 		{Key: "resetPassCodeExp", Value: time.Now().Add(time.Minute * 15).Unix()},
 	},
 	}}
-	_, err := Collection.UpdateOne(context.TODO(), filter, update)
+	_, err := UserCollection.UpdateOne(context.TODO(), filter, update)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -250,7 +250,7 @@ func AddItemToUserInventory(userId primitive.ObjectID, item interfaces.GymReward
 	}
 
 	// Update the user document
-	_, err := Collection.UpdateOne(
+	_, err := UserCollection.UpdateOne(
 		context.TODO(),
 		bson.D{{Key: "_id", Value: userId}},
 		bson.D{

--- a/api/models/user.go
+++ b/api/models/user.go
@@ -47,7 +47,7 @@ next:
 	return nil
 }
 
-// todo
+// update password when its reset
 func UpdatePasword(email string, p string) error {
 	filter := bson.D{{Key: "email", Value: email}}
 	update := bson.D{{Key: "$set", Value: bson.D{
@@ -174,12 +174,64 @@ func CheckCodeExistence(email string, code string) bool {
 	}
 }
 
+func CheckResetPassCodeExistence(email string, code string) bool {
+
+	var usercode interfaces.ResetPasswordCode
+	filter := bson.D{{Key: "email", Value: email}}
+	err := Collection.FindOne(context.TODO(), filter).Decode(&usercode)
+	if err != nil {
+		fmt.Println(err)
+	}
+	// check time expiration
+	if !time.Now().Before(time.Unix(usercode.ResetPassCodeExp, 0)) {
+		// clean ResetPassCode field
+		filter := bson.D{{Key: "email", Value: usercode.Email}}
+		update := bson.D{{Key: "$set", Value: bson.D{
+			{Key: "resetPassCode", Value: nil},
+		},
+		}}
+		Collection.UpdateOne(context.TODO(), filter, update)
+		return false
+	}
+
+	// verify code
+	if code != usercode.ResetPassCode {
+		return false
+	} else {
+		// clean fields related to reset password code
+		filter := bson.D{{Key: "email", Value: usercode.Email}}
+		update := bson.D{{Key: "$set", Value: bson.D{
+			{Key: "resetPassCode", Value: nil},
+			{Key: "resetPassCodeExp", Value: nil},
+		},
+		}}
+		Collection.UpdateOne(context.TODO(), filter, update)
+		return true
+	}
+}
+
 func UpdateCode(email string, validationCode string) error {
 	// update code and expiration time
 	filter := bson.D{{Key: "email", Value: email}}
 	update := bson.D{{Key: "$set", Value: bson.D{
 		{Key: "validationCode", Value: validationCode},
 		{Key: "validationCodeExp", Value: time.Now().Add(time.Minute * 15).Unix()},
+	},
+	}}
+	_, err := Collection.UpdateOne(context.TODO(), filter, update)
+	if err != nil {
+		fmt.Println(err)
+	}
+	return err
+}
+
+// update the fields of code to reset password and its expiration time in db
+func UpdateResetPassCode(email string, resetPassCode string) error {
+	// update code and expiration time
+	filter := bson.D{{Key: "email", Value: email}}
+	update := bson.D{{Key: "$set", Value: bson.D{
+		{Key: "resetPassCode", Value: resetPassCode},
+		{Key: "resetPassCodeExp", Value: time.Now().Add(time.Minute * 15).Unix()},
 	},
 	}}
 	_, err := Collection.UpdateOne(context.TODO(), filter, update)

--- a/api/models/user.go
+++ b/api/models/user.go
@@ -47,6 +47,20 @@ next:
 	return nil
 }
 
+// todo
+func UpdatePasword(email string, p string) error {
+	filter := bson.D{{Key: "email", Value: email}}
+	update := bson.D{{Key: "$set", Value: bson.D{
+		{Key: "password", Value: p},
+	},
+	}}
+	_, err := Collection.UpdateOne(context.TODO(), filter, update)
+	if err != nil {
+		fmt.Println(err)
+	}
+	return err
+}
+
 // GetUserByEmail returns a user by its email and an error (if any)
 func GetUserByEmail(email string) (interfaces.User, error) {
 	var userE interfaces.User

--- a/api/routes/router.go
+++ b/api/routes/router.go
@@ -11,8 +11,8 @@ func SetupRoutes(engine *gin.Engine) {
 	engine.POST("/signup", controllers.HandleSignUp)
 	engine.POST("/code_validation", controllers.HandleCodeValidation)
 	engine.POST("/new_code", controllers.HandleNewCodeValidation)
-	engine.POST("/reset_password", controllers.HandleCodeResetPassword)
-	engine.PUT("/reset_password", controllers.HandleResetPassword)
+	engine.POST("/user/password/code", controllers.HandleCodeResetPassword)
+	engine.PUT("/user/password", controllers.HandleResetPassword)
 
 	// Session
 	engine.POST("/login", controllers.HandleLogIn)

--- a/api/routes/router.go
+++ b/api/routes/router.go
@@ -11,6 +11,8 @@ func SetupRoutes(engine *gin.Engine) {
 	engine.POST("/signup", controllers.HandleSignUp)
 	engine.POST("/code_validation", controllers.HandleCodeValidation)
 	engine.POST("/new_code", controllers.HandleNewCodeValidation)
+	engine.POST("/reset_password", controllers.HandleCodeResetPassword)
+	engine.PUT("/reset_password", controllers.HandleResetPassword)
 
 	// Session
 	engine.POST("/login", controllers.HandleLogIn)


### PR DESCRIPTION
- 2 new fields in `users` collection: `resetPassCode` y`resetPassCodeExp` (time expiration) are included (the idea is in a future PR, create a new collection with fields like `resetPassCode` or `validationCode`)
- A code is created and added in `resetPassCode` when user request reset the password and its sended to the mail. To prove this, make a POST request to `/reset_password` including in the body the email that needs reset the password.
- Prove making a PUT request to `/reset_password`, to change password:
`{
	"email": "youremail@mail.com",
	"resetPassCode": "######",
	"password": "NewPassword"
}` 