### PR TITLE
Fix: Get near loomies even if noone

### DIFF
--- a/.github/docs/openapi.yml
+++ b/.github/docs/openapi.yml
@@ -510,7 +510,7 @@ paths:
         required: true
       responses: 
         "200": 
-          description: There wasn't any error and the neares loomies are retrieved.
+          description: There wasn't any error and the nearest loomies are retrieved.
           content: 
             application/json: 
               schema: 
@@ -528,12 +528,6 @@ paths:
                       $ref: "#/components/schemas/PublicWildLoomie"
         "401":
           description: The access token wasn't provided or isn't valid.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/FailResponse"
-        "404":
-          description: No loomies were found near the user coordinates.
           content:
             application/json:
               schema:

--- a/api/controllers/loomies.go
+++ b/api/controllers/loomies.go
@@ -151,16 +151,6 @@ func HandleNearLoomies(c *gin.Context) {
 		return
 	}
 
-	if len(wildLoomies) == 0 {
-		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{
-			"error":   true,
-			"message": "No loomies found",
-			"loomies": wildLoomies,
-		})
-
-		return
-	}
-
 	c.IndentedJSON(http.StatusOK, gin.H{
 		"error":   false,
 		"message": "Loomies were retrieved successfully",


### PR DESCRIPTION
When there are no Loomies nearby just send an empty array.

0 Loomies is also an okay quantity to send.