### PR TITLE
Fix: Outdated loomies

### DIFF
--- a/algorithms/backups/README.md
+++ b/algorithms/backups/README.md
@@ -1,0 +1,14 @@
+## 💾 Backups
+
+This folder contains the bash script used to backup the database.
+
+- **Execution period:** At 01:00 AM, only on Tuesday, Thursday, and Saturday
+- **Required arguments:**
+
+| Pos. | Name             | Description                                                     | Example                                               |
+| ---- | ---------------- | --------------------------------------------------------------- | ----------------------------------------------------- |
+| 1    | Hosts            | Comma separated mongodb hosts                                   | mongodb0.example.com:27017,mongodb1.example.com:27017 |
+| 2    | Backup Directory | Directory to save the backup output                             | /home/server/backups                                  |
+| 3    | User             | Database user with permissions to execute the mongodump command | admin                                                 |
+| 4    | Drive Folder Id  | Google Drive folder id to save the backup                       | 1a2b3...                                              |
+| 5    | Password         | Database user's password                                        | password                                              |

--- a/algorithms/database/cronjobs/README.md
+++ b/algorithms/database/cronjobs/README.md
@@ -1,25 +1,35 @@
-# Algorithms/database/cronjobs
+# 💽 Database Cronjobs
 
 This directory contains the cronjobs (scheduled tasks) related to the database.
 
-## 🔥 Remove Outdated Loomies
+## 🧹 Clear Loomies
 
 This cronjob removes outdated loomies from the database.
 
-- To remove outdated loomies run the following command from the `algorithms/database` directory:
+### Outdated Loomies
 
 ```bash
-pnpm clear:outdated
+pnpm clear_loomies:outdated
 ```
 
-- To remove all the loomies run the following command from the `algorithms/database` directory:
+**Execution period:** Every 24 hours
+
+### All Loomies
 
 ```bash
-pnpm clear:all
+pnpm clear_loomies:all
 ```
 
 **Note:** Before running the clear:outdated command, make sure you have a .env file in the `algorithms/database` directory with the OUTDATED_LOOMIES_TIMEOUT variable set to the desired value
 
 ## ✨ Gyms rewards
 
-Working on it...
+This cronjob updates the rewards of the gyms in the database.
+
+- To update the rewards of the gyms run the following command from the `algorithms/database` directory:
+
+```bash
+pnpm update:rewards
+```
+
+**Execution period:** Every 24 hours

--- a/algorithms/database/package.json
+++ b/algorithms/database/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "bulk": "node bulk.js",
     "test": "vitest",
-    "clear:outdated": "node cronjobs/remove_outdated_loomies/remove.js --outdated",
-    "clear:all": "node cronjobs/remove_outdated_loomies/remove.js --all",
+    "clear_loomies:outdated": "node cronjobs/remove_outdated_loomies/remove.js --outdated",
+    "clear_loomies:all": "node cronjobs/remove_outdated_loomies/remove.js --all",
     "update:rewards": "node cronjobs/update_gyms_rewards/update.js"
   },
   "keywords": [],

--- a/api/.env.example
+++ b/api/.env.example
@@ -7,6 +7,8 @@ ACCESS_TOKEN_SECRET = some_secret_string_2
 WS_TOKEN_SECRET = some_secret_string_3
 # The width of each zone
 GAME_ZONE_RADIUS = 0.0035
+# The time to live of a loomie (in minutes)
+GAME_WILD_LOOMIES_TTL = 15
 # Minutes to wait before generating new loomies
 GAME_MIN_LOOMIES_GENERATION_TIMEOUT = 5
 GAME_MAX_LOOMIES_GENERATION_TIMEOUT = 12

--- a/api/configuration/configuration.go
+++ b/api/configuration/configuration.go
@@ -74,6 +74,22 @@ func GetRefreshTokenSecret() string {
 	return Globals.RefreshTokenSecret
 }
 
+// GetWildLoomiesTTL Returns the value of the GAME_WILD_LOOMIES_TTL environment variable and update the global variable if it is empty
+func GetWildLoomiesTTL() int {
+	if Globals.WildLoomiesTTL == 0 {
+		// Get the value (as a string) from the environment
+		wildLoomiesTTLString := GetEnvironmentVariable("GAME_WILD_LOOMIES_TTL")
+
+		// Convert the string to an integer
+		wildLoomiesTTL, _ := strconv.Atoi(wildLoomiesTTLString)
+
+		// Set the value in the globals
+		Globals.WildLoomiesTTL = wildLoomiesTTL
+	}
+
+	return Globals.WildLoomiesTTL
+}
+
 func GetLoomiesGenerationTimeouts() (int, int) {
 	if Globals.MinLoomiesGenerationTimeout == 0 || Globals.MaxLoomiesGenerationTimeout == 0 {
 		// Get values (as strings) from the environment

--- a/api/configuration/interfaces.go
+++ b/api/configuration/interfaces.go
@@ -12,6 +12,7 @@ type TGlobals struct {
 	RefreshTokenSecret          string
 	WsTokenSecret               string
 	WsHub                       *combat.WsHub
+	WildLoomiesTTL              int
 	MinLoomiesGenerationTimeout int
 	MaxLoomiesGenerationTimeout int
 	MinLoomiesGenerationAmount  int


### PR DESCRIPTION
### Includes: 

- [x] Remove the outdated Loomies from the `/loomies/near` response.

### How can I test this? 

1. Generate some Loomies using the `/loomies/near` endpoint. 
2. (Optional) Modify the `GAME_WILD_LOOMIES_TTL` environment variable to a lower value (in minutes, Eg. 1) or decrease the `generated_at` field of the loomies in the Wild Loomies collection.
3. Wait the expiration time and send a request to the `/loomies/near` endpoint again, you shouldn't see the expirated loomies. 

--- 

**Note:** There is already an script to remove outdated loomies on `/algorithms/database/cronjobs/remove_outdated_loomies`. You can use the `pnpm clear:outdated` or `npm run clear:outdated` command to execute it. 

Closes #84. 