### PR TITLE
Test: Add missing user endpoints tests

### DIFF
--- a/api/configuration/configuration.go
+++ b/api/configuration/configuration.go
@@ -19,8 +19,8 @@ var Globals = TGlobals{}
 func load() {
 	environment := os.Getenv("ENVIRONMENT")
 
-	// If the environment is production, do not load the .env file
-	if environment == "production" {
+	// If the environment is PRODUCTION, do not load the .env file
+	if environment == "PRODUCTION" {
 		return
 	}
 
@@ -30,7 +30,17 @@ func load() {
 		log.Fatal("Error loading .env file")
 	}
 
+	Globals.Environment = environment
 	Globals.Loaded = true
+}
+
+// GetRunningEnvironment returns the value of the ENVIRONMENT environment variable
+func GetRunningEnvironment() string {
+	if Globals.Loaded == false {
+		load()
+	}
+
+	return Globals.Environment
 }
 
 // GetEnvironmentVariable returns the value of the environment variable with the given name

--- a/api/configuration/interfaces.go
+++ b/api/configuration/interfaces.go
@@ -6,6 +6,7 @@ import (
 )
 
 type TGlobals struct {
+	Environment                 string
 	Loaded                      bool
 	MongoClient                 *mongo.Client
 	AccessTokenSecret           string

--- a/api/controllers/session_test.go
+++ b/api/controllers/session_test.go
@@ -39,7 +39,7 @@ func loginWithRandomUser() (interfaces.User, map[string]string) {
 	}
 
 	router.POST("/session/login", HandleLogIn)
-	w, req := tests.SetupPostRequest("/session/login", loginForm)
+	w, req := tests.SetupPayloadedRequest("/session/login", "POST", loginForm)
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
 
@@ -67,7 +67,7 @@ func TestLoginForbidden(t *testing.T) {
 	}
 
 	router.POST("/session/login", HandleLogIn)
-	w, req := tests.SetupPostRequest("/session/login", loginForm)
+	w, req := tests.SetupPayloadedRequest("/session/login", "POST", loginForm)
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
 
@@ -104,7 +104,7 @@ func TestLoginSuccess(t *testing.T) {
 	}
 
 	router.POST("/session/login", HandleLogIn)
-	w, req := tests.SetupPostRequest("/session/login", loginForm)
+	w, req := tests.SetupPayloadedRequest("/session/login", "POST", loginForm)
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
 
@@ -144,7 +144,7 @@ func TestRefreshUnauthorized(t *testing.T) {
 	// Try to refresh without a refresh token
 	var refreshResponse map[string]string
 	router.POST("/session/refresh", middlewares.MustProvideRefreshToken(), HandleRefresh)
-	w, req := tests.SetupPostRequest("/session/refresh", nil)
+	w, req := tests.SetupPayloadedRequest("/session/refresh", "POST", nil)
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &refreshResponse)
 
@@ -166,7 +166,7 @@ func TestRefreshSuccess(t *testing.T) {
 	// Get a new access token from the refresh token
 	var refreshResponse map[string]string
 	router.POST("/session/refresh", middlewares.MustProvideRefreshToken(), HandleRefresh)
-	w, req := tests.SetupPostRequest("/session/refresh", nil, tests.CustomHeader{Name: "Refresh-Token", Value: loginResponse["refreshToken"]})
+	w, req := tests.SetupPayloadedRequest("/session/refresh", "POST", nil, tests.CustomHeader{Name: "Refresh-Token", Value: loginResponse["refreshToken"]})
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &refreshResponse)
 

--- a/api/controllers/session_test.go
+++ b/api/controllers/session_test.go
@@ -76,7 +76,8 @@ func TestLoginForbidden(t *testing.T) {
 	c.Equal("User has not been verified", response["message"])
 
 	// Delete the user from the database
-	usersCollection.DeleteOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}})
+	err := tests.DeleteUser(randomUser.Email)
+	c.NoError(err)
 }
 
 // TestSignupSuccess tests the signup endpoint with a verified user
@@ -131,7 +132,8 @@ func TestLoginSuccess(t *testing.T) {
 	c.Equal(databaseUser.Id.Hex(), refreshTokenClaims["userid"])
 
 	// Delete the user from the database
-	usersCollection.DeleteOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}})
+	err = tests.DeleteUser(randomUser.Email)
+	c.NoError(err)
 }
 
 // TestRefreshUnauthorized tests the refresh endpoint without a refresh token
@@ -183,7 +185,8 @@ func TestRefreshSuccess(t *testing.T) {
 	c.Equal(databaseUser.Id.Hex(), accessTokenClaims["userid"])
 
 	// Remove the user from the database
-	usersCollection.DeleteOne(ctx, bson.D{{Key: "email", Value: databaseUser.Email}})
+	err = tests.DeleteUser(databaseUser.Email)
+	c.NoError(err)
 }
 
 // TestWhoamiUnauthorized tests the whoami endpoint without a valid access token
@@ -229,5 +232,6 @@ func TestWhoamiSuccess(t *testing.T) {
 	c.Equal(databaseUser.Username, whoamiResponseUser["username"])
 
 	// Remove the user from the database
-	usersCollection.DeleteOne(ctx, bson.D{{Key: "email", Value: databaseUser.Email}})
+	err := tests.DeleteUser(databaseUser.Email)
+	c.NoError(err)
 }

--- a/api/controllers/session_test.go
+++ b/api/controllers/session_test.go
@@ -76,7 +76,7 @@ func TestLoginForbidden(t *testing.T) {
 	c.Equal("User has not been verified", response["message"])
 
 	// Delete the user from the database
-	err := tests.DeleteUser(randomUser.Email)
+	err := tests.DeleteUser(randomUser.Email, randomUser.Id)
 	c.NoError(err)
 }
 
@@ -132,7 +132,7 @@ func TestLoginSuccess(t *testing.T) {
 	c.Equal(databaseUser.Id.Hex(), refreshTokenClaims["userid"])
 
 	// Delete the user from the database
-	err = tests.DeleteUser(randomUser.Email)
+	err = tests.DeleteUser(randomUser.Email, randomUser.Id)
 	c.NoError(err)
 }
 
@@ -185,7 +185,7 @@ func TestRefreshSuccess(t *testing.T) {
 	c.Equal(databaseUser.Id.Hex(), accessTokenClaims["userid"])
 
 	// Remove the user from the database
-	err = tests.DeleteUser(databaseUser.Email)
+	err = tests.DeleteUser(databaseUser.Email, databaseUser.Id)
 	c.NoError(err)
 }
 
@@ -232,6 +232,6 @@ func TestWhoamiSuccess(t *testing.T) {
 	c.Equal(databaseUser.Username, whoamiResponseUser["username"])
 
 	// Remove the user from the database
-	err := tests.DeleteUser(databaseUser.Email)
+	err := tests.DeleteUser(databaseUser.Email, databaseUser.Id)
 	c.NoError(err)
 }

--- a/api/controllers/session_test.go
+++ b/api/controllers/session_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/PedroChaparro/loomies-backend/configuration"
 	"github.com/PedroChaparro/loomies-backend/interfaces"
 	"github.com/PedroChaparro/loomies-backend/middlewares"
+	"github.com/PedroChaparro/loomies-backend/models"
 	"github.com/PedroChaparro/loomies-backend/tests"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/require"
@@ -16,7 +17,6 @@ import (
 )
 
 // ## Helper functions
-
 // loginWithRandomUser creates a random user, inserts it into the database, verifies it and tries to login with it
 func loginWithRandomUser() (interfaces.User, map[string]string) {
 	ctx := context.Background()
@@ -28,8 +28,8 @@ func loginWithRandomUser() (interfaces.User, map[string]string) {
 
 	// Verify the user and save the database document
 	var databaseUser interfaces.User
-	usersCollection.UpdateOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}}, bson.D{{Key: "$set", Value: bson.D{{Key: "isVerified", Value: true}}}})
-	usersCollection.FindOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}}).Decode(&databaseUser)
+	models.UserCollection.UpdateOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}}, bson.D{{Key: "$set", Value: bson.D{{Key: "isVerified", Value: true}}}})
+	models.UserCollection.FindOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}}).Decode(&databaseUser)
 
 	// Try to login with the random user
 	var response map[string]string
@@ -93,9 +93,9 @@ func TestLoginSuccess(t *testing.T) {
 	tests.InsertUser(randomUser, router, HandleSignUp)
 
 	// Verify the user and save the database document
-	usersCollection.UpdateOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}}, bson.D{{Key: "$set", Value: bson.D{{Key: "isVerified", Value: true}}}})
+	models.UserCollection.UpdateOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}}, bson.D{{Key: "$set", Value: bson.D{{Key: "isVerified", Value: true}}}})
 	var databaseUser interfaces.User
-	usersCollection.FindOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}}).Decode(&databaseUser)
+	models.UserCollection.FindOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}}).Decode(&databaseUser)
 
 	// Try to login with the random user
 	loginForm := map[string]string{

--- a/api/controllers/user.go
+++ b/api/controllers/user.go
@@ -174,7 +174,7 @@ func HandleAccountValidationCodeRequest(c *gin.Context) {
 	}
 
 	if userDoc.IsVerified {
-		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": true, "message": "This Email has been already verified"})
+		c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": true, "message": "This Email has been already verified"})
 		return
 	}
 

--- a/api/controllers/user.go
+++ b/api/controllers/user.go
@@ -147,7 +147,7 @@ func HandleAccountValidation(c *gin.Context) {
 		c.IndentedJSON(http.StatusOK, gin.H{"error": false, "message": "Email has been verified"})
 		return
 	} else {
-		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": true, "message": "Code was incorrect or time has expired"})
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": true, "message": "Code was incorrect or time has expired"})
 		return
 	}
 }

--- a/api/controllers/user.go
+++ b/api/controllers/user.go
@@ -307,7 +307,7 @@ func HandleResetPassword(c *gin.Context) {
 			return
 		}
 	} else {
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": true, "message": "Password is too short"})
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": true, "message": "Password must be at least 8 characters long"})
 		return
 	}
 

--- a/api/controllers/user_test.go
+++ b/api/controllers/user_test.go
@@ -33,7 +33,7 @@ func TestSignupSuccessAndConflict(t *testing.T) {
 	router.POST("/user/signup", HandleSignUp)
 
 	// Make the request and get the JSON response
-	w, req := tests.SetupPostRequest("/user/signup", payload)
+	w, req := tests.SetupPayloadedRequest("/user/signup", "POST", payload)
 	_, err := ioutil.ReadAll(w.Body)
 	router.ServeHTTP(w, req)
 	var response map[string]string
@@ -56,7 +56,7 @@ func TestSignupSuccessAndConflict(t *testing.T) {
 	// -------------------------
 	// 2. Conflict request with the same email
 	// -------------------------
-	w, req = tests.SetupPostRequest("/user/signup", payload)
+	w, req = tests.SetupPayloadedRequest("/user/signup", "POST", payload)
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
 
@@ -69,7 +69,7 @@ func TestSignupSuccessAndConflict(t *testing.T) {
 	// -------------------------
 	oldEmail := payload.Email
 	payload.Email = tests.FakerInstance.Internet().Email()
-	w, req = tests.SetupPostRequest("/user/signup", payload)
+	w, req = tests.SetupPayloadedRequest("/user/signup", "POST", payload)
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
 
@@ -98,7 +98,7 @@ func TestAccountValidationCodeSuccess(t *testing.T) {
 
 	// Make the request and get the JSON response
 	router.POST("/user/validate/code", HandleAccountValidationCodeRequest)
-	w, req := tests.SetupPostRequest("/user/validate/code", map[string]string{"email": randomUser.Email})
+	w, req := tests.SetupPayloadedRequest("/user/validate/code", "POST", map[string]string{"email": randomUser.Email})
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
 
@@ -128,7 +128,7 @@ func TestAccountValidationCodeBadRequest(t *testing.T) {
 	// 1. Test without JSON payload
 	// -------------------------
 	router.POST("/user/validate/code", HandleAccountValidationCodeRequest)
-	w, req := tests.SetupPostRequest("/user/validate/code", nil)
+	w, req := tests.SetupPayloadedRequest("/user/validate/code", "POST", nil)
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
 
@@ -139,7 +139,7 @@ func TestAccountValidationCodeBadRequest(t *testing.T) {
 	// -------------------------
 	// 2. Test with empty email
 	// -------------------------
-	w, req = tests.SetupPostRequest("/user/validate/code", map[string]string{"email": ""})
+	w, req = tests.SetupPayloadedRequest("/user/validate/code", "POST", map[string]string{"email": ""})
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
 
@@ -150,7 +150,7 @@ func TestAccountValidationCodeBadRequest(t *testing.T) {
 	// -------------------------
 	// 3. Test with unregistred email
 	// -------------------------
-	w, req = tests.SetupPostRequest("/user/validate/code", map[string]string{"email": "unexisting@gmail.com"})
+	w, req = tests.SetupPayloadedRequest("/user/validate/code", "POST", map[string]string{"email": "unexisting@gmail.com"})
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
 
@@ -162,7 +162,7 @@ func TestAccountValidationCodeBadRequest(t *testing.T) {
 	// 4. Test with verified email
 	// -------------------------
 	models.UserCollection.UpdateOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}}, bson.D{{Key: "$set", Value: bson.D{{Key: "isVerified", Value: true}}}})
-	w, req = tests.SetupPostRequest("/user/validate/code", map[string]string{"email": randomUser.Email})
+	w, req = tests.SetupPayloadedRequest("/user/validate/code", "POST", map[string]string{"email": randomUser.Email})
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
 
@@ -194,7 +194,7 @@ func TestAccountValidationSuccess(t *testing.T) {
 
 	// Make the request and get the JSON response
 	router.POST("/user/validate", HandleAccountValidation)
-	w, req := tests.SetupPostRequest("/user/validate", map[string]string{"email": randomUser.Email, "validationCode": code.Code})
+	w, req := tests.SetupPayloadedRequest("/user/validate", "POST", map[string]string{"email": randomUser.Email, "validationCode": code.Code})
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
 
@@ -226,7 +226,7 @@ func TestAccountValidationBadRequest(t *testing.T) {
 	// 1. Test without JSON payload
 	// -------------------------
 	router.POST("/user/validate", HandleAccountValidation)
-	w, req := tests.SetupPostRequest("/user/validate", nil)
+	w, req := tests.SetupPayloadedRequest("/user/validate", "POST", nil)
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
 
@@ -237,7 +237,7 @@ func TestAccountValidationBadRequest(t *testing.T) {
 	// -------------------------
 	// 2. Test with empty email
 	// -------------------------
-	w, req = tests.SetupPostRequest("/user/validate", map[string]string{"email": "", "validationCode": code.Code})
+	w, req = tests.SetupPayloadedRequest("/user/validate", "POST", map[string]string{"email": "", "validationCode": code.Code})
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
 
@@ -248,7 +248,7 @@ func TestAccountValidationBadRequest(t *testing.T) {
 	// -------------------------
 	// 3. Test with empty validationCode
 	// -------------------------
-	w, req = tests.SetupPostRequest("/user/validate", map[string]string{"email": randomUser.Email, "validationCode": ""})
+	w, req = tests.SetupPayloadedRequest("/user/validate", "POST", map[string]string{"email": randomUser.Email, "validationCode": ""})
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
 
@@ -259,7 +259,7 @@ func TestAccountValidationBadRequest(t *testing.T) {
 	// -------------------------
 	// 4. Test with incorrect validationCode
 	// -------------------------
-	w, req = tests.SetupPostRequest("/user/validate", map[string]string{"email": randomUser.Email, "validationCode": strconv.Itoa(codeNumber + 1)})
+	w, req = tests.SetupPayloadedRequest("/user/validate", "POST", map[string]string{"email": randomUser.Email, "validationCode": strconv.Itoa(codeNumber + 1)})
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
 
@@ -290,7 +290,7 @@ func TestPasswordResetCodeSuccess(t *testing.T) {
 
 	// Make the request and get the JSON response
 	router.POST("/user/password/code", HandleResetPasswordCodeRequest)
-	w, req := tests.SetupPostRequest("/user/password/code", map[string]string{"email": randomUser.Email})
+	w, req := tests.SetupPayloadedRequest("/user/password/code", "POST", map[string]string{"email": randomUser.Email})
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
 
@@ -316,7 +316,7 @@ func TestPasswordResetCodeBadRequest(t *testing.T) {
 	// 1. Test without JSON payload
 	// -------------------------
 	router.POST("/user/password/code", HandleResetPasswordCodeRequest)
-	w, req := tests.SetupPostRequest("/user/password/code", nil)
+	w, req := tests.SetupPayloadedRequest("/user/password/code", "POST", nil)
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
 
@@ -327,7 +327,7 @@ func TestPasswordResetCodeBadRequest(t *testing.T) {
 	// -------------------------
 	// 2. Test with empty email
 	// -------------------------
-	w, req = tests.SetupPostRequest("/user/password/code", map[string]string{"email": ""})
+	w, req = tests.SetupPayloadedRequest("/user/password/code", "POST", map[string]string{"email": ""})
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
 
@@ -338,13 +338,204 @@ func TestPasswordResetCodeBadRequest(t *testing.T) {
 	// -------------------------
 	// 3. Test with non-existent email
 	// -------------------------
-	w, req = tests.SetupPostRequest("/user/password/code", map[string]string{"email": "645031e5-14da-45c8-abb7-714ded7d1ad9@gmail.com"})
+	w, req = tests.SetupPayloadedRequest("/user/password/code", "POST", map[string]string{"email": "645031e5-14da-45c8-abb7-714ded7d1ad9@gmail.com"})
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
 
 	c.Equal(http.StatusNotFound, w.Code)
 	c.Equal(true, response["error"])
 	c.Equal("This Email has not been registered", response["message"])
+}
+
+// TestPasswordResetSuccess Test the success case for /user/password/reset endpoint
+func TestPasswordResetSuccess(t *testing.T) {
+	var response map[string]interface{}
+	c := require.New(t)
+	ctx := context.Background()
+	defer ctx.Done()
+
+	// Create a random user
+	randomUser := tests.GenerateRandomUser()
+	router := tests.SetupGinRouter()
+	tests.InsertUser(randomUser, router, HandleSignUp)
+
+	// Verify the user directly on the database
+	_, err := models.UserCollection.UpdateOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}}, bson.D{{Key: "$set", Value: bson.D{{Key: "isVerified", Value: true}}}})
+	c.NoError(err)
+
+	// Send a request to get a new password reset code
+	router.POST("/user/password/code", HandleResetPasswordCodeRequest)
+	w, req := tests.SetupPayloadedRequest("/user/password/code", "POST", map[string]string{"email": randomUser.Email})
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &response)
+	c.Equal(http.StatusOK, w.Code)
+
+	// Get the code from the database
+	var passwordResetCode interfaces.AuthenticationCode
+	err = models.AuthenticationCodesCollection.FindOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}, {Key: "type", Value: "RESET_PASSWORD"}}).Decode(&passwordResetCode)
+	c.NoError(err)
+
+	// -------------------------
+	// 1. Test to reset the password
+	router.PUT("/user/password/reset", HandleResetPassword)
+	w, req = tests.SetupPayloadedRequest("/user/password/reset", "PUT", map[string]string{"email": randomUser.Email, "resetPassCode": passwordResetCode.Code, "password": "NewPassword2023*/"})
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	c.Equal(http.StatusOK, w.Code)
+	c.Equal(false, response["error"])
+	c.Equal("Password has been changed successfully", response["message"])
+
+	// -------------------------
+	// 2. Test to log in with the new password
+	router.POST("/session/login", HandleLogIn)
+	w, req = tests.SetupPayloadedRequest("/session/login", "POST", map[string]string{"email": randomUser.Email, "password": "NewPassword2023*/"})
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	// Check the response
+	c.Equal(http.StatusOK, w.Code)
+	c.Equal(false, response["error"])
+	c.Equal("Successfully logged in", response["message"])
+
+	// -------------------------
+	// 3. Test to log in with the old password
+	w, req = tests.SetupPayloadedRequest("/session/login", "POST", map[string]string{"email": randomUser.Email, "password": randomUser.Password})
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	// Check the response
+	c.Equal(http.StatusUnauthorized, w.Code)
+	c.Equal(true, response["error"])
+	c.Equal("Wrong Email/Password", response["message"])
+
+	// Remove the user
+	err = tests.DeleteUser(randomUser.Email)
+	c.NoError(err)
+}
+
+// TestPasswordResetBadRequest Test the bad request cases for /user/password/reset endpoint
+func TestPasswordResetBadRequest(t *testing.T) {
+	var response map[string]interface{}
+	c := require.New(t)
+	ctx := context.Background()
+	defer ctx.Done()
+
+	// Create a random user
+	randomUser := tests.GenerateRandomUser()
+	router := tests.SetupGinRouter()
+	tests.InsertUser(randomUser, router, HandleSignUp)
+
+	// Verify the user directly on the database
+	_, err := models.UserCollection.UpdateOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}}, bson.D{{Key: "$set", Value: bson.D{{Key: "isVerified", Value: true}}}})
+	c.NoError(err)
+
+	// Send a request to get a new password reset code
+	router.POST("/user/password/code", HandleResetPasswordCodeRequest)
+	w, req := tests.SetupPayloadedRequest("/user/password/code", "POST", map[string]string{"email": randomUser.Email})
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &response)
+	c.Equal(http.StatusOK, w.Code)
+
+	// Get the code from the database
+	var passwordResetCode interfaces.AuthenticationCode
+	err = models.AuthenticationCodesCollection.FindOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}, {Key: "type", Value: "RESET_PASSWORD"}}).Decode(&passwordResetCode)
+	c.NoError(err)
+
+	// -------------------------
+	// 1. Test to reset the password with nil payload
+	router.PUT("/user/password/reset", HandleResetPassword)
+	w, req = tests.SetupPayloadedRequest("/user/password/reset", "PUT", nil)
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	c.Equal(http.StatusBadRequest, w.Code)
+	c.Equal(true, response["error"])
+	c.Equal("Bad request", response["message"])
+
+	// -------------------------
+	// 2. Test to reset the password with empty email
+	w, req = tests.SetupPayloadedRequest("/user/password/reset", "PUT", map[string]string{"email": "", "resetPassCode": passwordResetCode.Code, "password": "NewPassword2023*/"})
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	c.Equal(http.StatusBadRequest, w.Code)
+	c.Equal(true, response["error"])
+	c.Equal("Email cannot be empty", response["message"])
+
+	// -------------------------
+	// 3. Test to reset the password with empty resetPassCode
+	w, req = tests.SetupPayloadedRequest("/user/password/reset", "PUT", map[string]string{"email": randomUser.Email, "resetPassCode": "", "password": "NewPassword2023*/"})
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	c.Equal(http.StatusBadRequest, w.Code)
+	c.Equal(true, response["error"])
+	c.Equal("Verification code cannot be empty", response["message"])
+
+	// -------------------------
+	// 4. Test to reset the password with empty password
+	w, req = tests.SetupPayloadedRequest("/user/password/reset", "PUT", map[string]string{"email": randomUser.Email, "resetPassCode": passwordResetCode.Code, "password": ""})
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	c.Equal(http.StatusBadRequest, w.Code)
+	c.Equal(true, response["error"])
+	c.Equal("Password cannot be empty", response["message"])
+
+	// -------------------------
+	// 5. Test to reset the password with short password
+	w, req = tests.SetupPayloadedRequest("/user/password/reset", "PUT", map[string]string{"email": randomUser.Email, "resetPassCode": passwordResetCode.Code, "password": "123"})
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	c.Equal(http.StatusBadRequest, w.Code)
+	c.Equal(true, response["error"])
+	c.Equal("Password must be at least 8 characters long", response["message"])
+
+	// -------------------------
+	// 6. Test to reset the password with invalid password (No uppercase)
+	w, req = tests.SetupPayloadedRequest("/user/password/reset", "PUT", map[string]string{"email": randomUser.Email, "resetPassCode": passwordResetCode.Code, "password": "newpassword2023*/"})
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	c.Equal(http.StatusBadRequest, w.Code)
+	c.Equal(true, response["error"])
+	c.Equal("Password must have at least one upper case character", response["message"])
+
+	// -------------------------
+	// 7. Test to reset the password with invalid password (No lowercase)
+	w, req = tests.SetupPayloadedRequest("/user/password/reset", "PUT", map[string]string{"email": randomUser.Email, "resetPassCode": passwordResetCode.Code, "password": "NEWPASSWORD2023*/"})
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	c.Equal(http.StatusBadRequest, w.Code)
+	c.Equal(true, response["error"])
+	c.Equal("Password must have at least one lower case character", response["message"])
+
+	// -------------------------
+	// 8. Test to reset the password with invalid password (No number)
+	w, req = tests.SetupPayloadedRequest("/user/password/reset", "PUT", map[string]string{"email": randomUser.Email, "resetPassCode": passwordResetCode.Code, "password": "NewPassword*/"})
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	c.Equal(http.StatusBadRequest, w.Code)
+	c.Equal(true, response["error"])
+	c.Equal("Password must have at least one numeric character", response["message"])
+
+	// -------------------------
+	// 9. Test to reset the password with invalid password (No special character)
+	w, req = tests.SetupPayloadedRequest("/user/password/reset", "PUT", map[string]string{"email": randomUser.Email, "resetPassCode": passwordResetCode.Code, "password": "NewPassword2023"})
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	c.Equal(http.StatusBadRequest, w.Code)
+	c.Equal(true, response["error"])
+	c.Equal("Password must have at least one special character", response["message"])
+
+	// Remove the user
+	err = tests.DeleteUser(randomUser.Email)
+	c.NoError(err)
 }
 
 // TestGetLoomiesSuccess Test the success case for /user/loomies endpoint

--- a/api/controllers/user_test.go
+++ b/api/controllers/user_test.go
@@ -68,6 +68,7 @@ func TestSignupSuccessAndConflict(t *testing.T) {
 	// 3. Conflict request with the same username
 	// -------------------------
 	oldEmail := payload.Email
+	oldId := payload.Id
 	payload.Email = tests.FakerInstance.Internet().Email()
 	w, req = tests.SetupPayloadedRequest("/user/signup", "POST", payload)
 	router.ServeHTTP(w, req)
@@ -78,9 +79,9 @@ func TestSignupSuccessAndConflict(t *testing.T) {
 	c.Equal("Username already exists", response["message"])
 
 	// Delete users
-	err = tests.DeleteUser(oldEmail)
+	err = tests.DeleteUser(oldEmail, oldId)
 	c.NoError(err)
-	err = tests.DeleteUser(payload.Email)
+	err = tests.DeleteUser(payload.Email, payload.Id)
 	c.NoError(err)
 }
 
@@ -108,7 +109,7 @@ func TestAccountValidationCodeSuccess(t *testing.T) {
 	c.Equal("New Code created and sended", response["message"])
 
 	// Delete user
-	err := tests.DeleteUser(randomUser.Email)
+	err := tests.DeleteUser(randomUser.Email, randomUser.Id)
 	c.NoError(err)
 }
 
@@ -171,7 +172,7 @@ func TestAccountValidationCodeBadRequest(t *testing.T) {
 	c.Equal("This Email has been already verified", response["message"])
 
 	// Delete user
-	err := tests.DeleteUser(randomUser.Email)
+	err := tests.DeleteUser(randomUser.Email, randomUser.Id)
 	c.NoError(err)
 }
 
@@ -268,7 +269,7 @@ func TestAccountValidationBadRequest(t *testing.T) {
 	c.Equal("Code was incorrect or time has expired", response["message"])
 
 	// Remove the user
-	err = tests.DeleteUser(randomUser.Email)
+	err = tests.DeleteUser(randomUser.Email, randomUser.Id)
 	c.NoError(err)
 }
 
@@ -300,7 +301,7 @@ func TestPasswordResetCodeSuccess(t *testing.T) {
 	c.Equal("New Code, to reset password, created and sended", response["message"])
 
 	// Remove the user
-	err = tests.DeleteUser(randomUser.Email)
+	err = tests.DeleteUser(randomUser.Email, randomUser.Id)
 	c.NoError(err)
 }
 
@@ -410,7 +411,7 @@ func TestPasswordResetSuccess(t *testing.T) {
 	c.Equal("Wrong Email/Password", response["message"])
 
 	// Remove the user
-	err = tests.DeleteUser(randomUser.Email)
+	err = tests.DeleteUser(randomUser.Email, randomUser.Id)
 	c.NoError(err)
 }
 
@@ -534,7 +535,7 @@ func TestPasswordResetBadRequest(t *testing.T) {
 	c.Equal("Password must have at least one special character", response["message"])
 
 	// Remove the user
-	err = tests.DeleteUser(randomUser.Email)
+	err = tests.DeleteUser(randomUser.Email, randomUser.Id)
 	c.NoError(err)
 }
 
@@ -611,7 +612,7 @@ func TestGetLoomiesSuccess(t *testing.T) {
 	}
 
 	// Remove the user
-	err := tests.DeleteUser(randomUser.Email)
+	err := tests.DeleteUser(randomUser.Email, randomUser.Id)
 	c.NoError(err)
 }
 
@@ -703,6 +704,6 @@ func TestGetLoomieTeamSuccess(t *testing.T) {
 	}
 
 	// Remove the user
-	err := tests.DeleteUser(randomUser.Email)
+	err := tests.DeleteUser(randomUser.Email, randomUser.Id)
 	c.NoError(err)
 }

--- a/api/controllers/user_test.go
+++ b/api/controllers/user_test.go
@@ -10,14 +10,18 @@ import (
 
 	"github.com/PedroChaparro/loomies-backend/configuration"
 	"github.com/PedroChaparro/loomies-backend/interfaces"
+	"github.com/PedroChaparro/loomies-backend/middlewares"
 	"github.com/PedroChaparro/loomies-backend/tests"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 // ### Global variables ###
 var usersCollection = configuration.ConnectToMongoCollection("users")
 var authenticationCodesCollection = configuration.ConnectToMongoCollection("authentication_codes")
+var caughtLoomiesCollection = configuration.ConnectToMongoCollection("caught_loomies")
 
 // ### Tests ###
 // TestSignupSuccessAndConflict Tests the signup endpoint with a valid payload and a payload with an already existing email / username
@@ -40,7 +44,9 @@ func TestSignupSuccessAndConflict(t *testing.T) {
 	var response map[string]string
 	json.Unmarshal(w.Body.Bytes(), &response)
 
+	// -------------------------
 	// 1. Success request
+	// -------------------------
 	c.NoError(err)
 	c.Equal(http.StatusOK, w.Code)
 	c.Equal("User created successfully", response["message"])
@@ -52,7 +58,9 @@ func TestSignupSuccessAndConflict(t *testing.T) {
 	c.Equal(payload.Email, user.Email)
 	c.Equal(payload.Username, user.Username)
 
+	// -------------------------
 	// 2. Conflict request with the same email
+	// -------------------------
 	w, req = tests.SetupPostRequest("/user/signup", payload)
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
@@ -61,7 +69,9 @@ func TestSignupSuccessAndConflict(t *testing.T) {
 	c.Equal(http.StatusConflict, w.Code)
 	c.Equal("Email already exists", response["message"])
 
+	// -------------------------
 	// 3. Conflict request with the same username
+	// -------------------------
 	oldEmail := payload.Email
 	payload.Email = tests.FakerInstance.Internet().Email()
 	w, req = tests.SetupPostRequest("/user/signup", payload)
@@ -119,7 +129,9 @@ func TestAccountValidationCodeBadRequest(t *testing.T) {
 	router := tests.SetupGinRouter()
 	tests.InsertUser(randomUser, router, HandleSignUp)
 
+	// -------------------------
 	// 1. Test without JSON payload
+	// -------------------------
 	router.POST("/user/validate/code", HandleAccountValidationCodeRequest)
 	w, req := tests.SetupPostRequest("/user/validate/code", nil)
 	router.ServeHTTP(w, req)
@@ -129,7 +141,9 @@ func TestAccountValidationCodeBadRequest(t *testing.T) {
 	c.Equal(true, response["error"])
 	c.Equal("Bad request", response["message"])
 
+	// -------------------------
 	// 2. Test with empty email
+	// -------------------------
 	w, req = tests.SetupPostRequest("/user/validate/code", map[string]string{"email": ""})
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
@@ -138,7 +152,9 @@ func TestAccountValidationCodeBadRequest(t *testing.T) {
 	c.Equal(true, response["error"])
 	c.Equal("Email cannot be empty", response["message"])
 
+	// -------------------------
 	// 3. Test with unregistred email
+	// -------------------------
 	w, req = tests.SetupPostRequest("/user/validate/code", map[string]string{"email": "unexisting@gmail.com"})
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
@@ -147,7 +163,9 @@ func TestAccountValidationCodeBadRequest(t *testing.T) {
 	c.Equal(true, response["error"])
 	c.Equal("This Email has not been registered", response["message"])
 
+	// -------------------------
 	// 4. Test with verified email
+	// -------------------------
 	usersCollection.UpdateOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}}, bson.D{{Key: "$set", Value: bson.D{{Key: "isVerified", Value: true}}}})
 	w, req = tests.SetupPostRequest("/user/validate/code", map[string]string{"email": randomUser.Email})
 	router.ServeHTTP(w, req)
@@ -209,7 +227,9 @@ func TestAccountValidationBadRequest(t *testing.T) {
 	c.NoError(err)
 	codeNumber, _ := strconv.Atoi(code.Code)
 
+	// -------------------------
 	// 1. Test without JSON payload
+	// -------------------------
 	router.POST("/user/validate", HandleAccountValidation)
 	w, req := tests.SetupPostRequest("/user/validate", nil)
 	router.ServeHTTP(w, req)
@@ -219,7 +239,9 @@ func TestAccountValidationBadRequest(t *testing.T) {
 	c.Equal(true, response["error"])
 	c.Equal("Bad request", response["message"])
 
+	// -------------------------
 	// 2. Test with empty email
+	// -------------------------
 	w, req = tests.SetupPostRequest("/user/validate", map[string]string{"email": "", "validationCode": code.Code})
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
@@ -228,7 +250,9 @@ func TestAccountValidationBadRequest(t *testing.T) {
 	c.Equal(true, response["error"])
 	c.Equal("Email cannot be empty", response["message"])
 
+	// -------------------------
 	// 3. Test with empty validationCode
+	// -------------------------
 	w, req = tests.SetupPostRequest("/user/validate", map[string]string{"email": randomUser.Email, "validationCode": ""})
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
@@ -237,7 +261,9 @@ func TestAccountValidationBadRequest(t *testing.T) {
 	c.Equal(true, response["error"])
 	c.Equal("Verification code cannot be empty", response["message"])
 
+	// -------------------------
 	// 4. Test with incorrect validationCode
+	// -------------------------
 	w, req = tests.SetupPostRequest("/user/validate", map[string]string{"email": randomUser.Email, "validationCode": strconv.Itoa(codeNumber + 1)})
 	router.ServeHTTP(w, req)
 	json.Unmarshal(w.Body.Bytes(), &response)
@@ -248,5 +274,80 @@ func TestAccountValidationBadRequest(t *testing.T) {
 
 	// Remove the user
 	err = tests.DeleteUser(randomUser.Email)
+	c.NoError(err)
+}
+
+// TestGetLoomiesSuccess Test the success case for /user/loomies endpoint
+func TestGetLoomiesSuccess(t *testing.T) {
+	var response map[string]interface{}
+	c := require.New(t)
+	ctx := context.Background()
+	defer ctx.Done()
+
+	// Create a random user
+	router := tests.SetupGinRouter()
+	randomUser, loginResponse := loginWithRandomUser()
+	token := loginResponse["accessToken"]
+
+	// -------------------------
+	// 1. Test with no loomies
+	// -------------------------
+	router.GET("/user/loomies", middlewares.MustProvideAccessToken(), HandleGetLoomies)
+	w, req := tests.SetupGetRequest("/user/loomies", tests.CustomHeader{Name: "Access-Token", Value: token})
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	c.Equal(http.StatusOK, w.Code)
+	c.Equal(false, response["error"])
+	c.Equal(0, len(response["loomies"].([]interface{})))
+
+	// -------------------------
+	// 2. Test with some loomies
+	// -------------------------
+	// Get the first 6 loomies from the caught_loomies collection
+	var loomies []interfaces.CaughtLoomie
+	var loomiesIds []primitive.ObjectID
+	cursor, _ := caughtLoomiesCollection.Find(ctx, bson.D{}, options.Find().SetLimit(6))
+	cursor.All(ctx, &loomies)
+	c.Equal(6, len(loomies))
+
+	// Get the ids of the loomies
+	for _, loomie := range loomies {
+		loomiesIds = append(loomiesIds, loomie.Id)
+	}
+
+	// Insert the loomies into the user's loomies
+	usersCollection.UpdateOne(ctx, bson.D{{Key: "email", Value: randomUser.Email}}, bson.D{{Key: "$set", Value: bson.D{{Key: "loomies", Value: loomiesIds}}}})
+
+	// Make the request and get the JSON response
+	w, req = tests.SetupGetRequest("/user/loomies", tests.CustomHeader{Name: "Access-Token", Value: token})
+	router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	c.Equal(http.StatusOK, w.Code)
+	c.Equal(false, response["error"])
+	c.Equal(6, len(response["loomies"].([]interface{})))
+
+	// Check the loomies fields
+	for _, loomie := range response["loomies"].([]interface{}) {
+		loomie := loomie.(map[string]interface{})
+		c.NotEmpty(loomie["_id"])
+		c.NotEmpty(loomie["serial"])
+		c.NotEmpty(loomie["name"])
+		c.NotEmpty(loomie["rarity"])
+		c.NotEmpty(loomie["hp"])
+		c.NotEmpty(loomie["attack"])
+		c.NotEmpty(loomie["defense"])
+		c.NotEmpty(loomie["is_busy"])
+		// Loomies cannot have less than 1 type
+		c.NotEmpty(loomie["types"])
+		c.GreaterOrEqual(len(loomie["types"].([]interface{})), 1)
+		// Default level is 1
+		c.NotEmpty(loomie["level"])
+		c.GreaterOrEqual(int(loomie["level"].(float64)), 1)
+	}
+
+	// Remove the user
+	err := tests.DeleteUser(randomUser.Email)
 	c.NoError(err)
 }

--- a/api/tests/tests_utils.go
+++ b/api/tests/tests_utils.go
@@ -32,17 +32,17 @@ func SetupGinRouter() *gin.Engine {
 	return router
 }
 
-// SetupPostRequest creates a new POST request with the given payload and headers (if any)
-func SetupPostRequest(endpoint string, payload interface{}, headers ...CustomHeader) (*httptest.ResponseRecorder, *http.Request) {
+// SetupPayloadedRequest creates a new POST or PUT request with the given payload and headers (if any)
+func SetupPayloadedRequest(endpoint string, method string, payload interface{}, headers ...CustomHeader) (*httptest.ResponseRecorder, *http.Request) {
 	var req *http.Request
 
 	if payload != nil {
 		payloadBytes, _ := json.Marshal(payload)
-		r, _ := http.NewRequest("POST", endpoint, bytes.NewReader(payloadBytes))
+		r, _ := http.NewRequest(method, endpoint, bytes.NewReader(payloadBytes))
 		req = r
 		req.Header.Set("Content-Type", "application/json")
 	} else {
-		r, _ := http.NewRequest("POST", endpoint, nil)
+		r, _ := http.NewRequest(method, endpoint, nil)
 		req = r
 	}
 
@@ -86,7 +86,7 @@ func GenerateRandomUser() interfaces.User {
 // endpoints that require a user to be logged in whintout having to test the signup endpoint
 func InsertUser(user interfaces.User, router *gin.Engine, handler gin.HandlerFunc) {
 	router.POST("/user/signup", handler)
-	w, req := SetupPostRequest("/user/signup", user)
+	w, req := SetupPayloadedRequest("/user/signup", "POST", user)
 	router.ServeHTTP(w, req)
 }
 

--- a/api/utils/email.go
+++ b/api/utils/email.go
@@ -4,11 +4,17 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/PedroChaparro/loomies-backend/configuration"
 	gomail "gopkg.in/gomail.v2"
 )
 
 // SendEmail sends an email to the specified address usint the specified subject and body
 func SendEmail(email string, subject string, validationCode string) error {
+	// Prevent sending emaails on test environment
+	if configuration.GetRunningEnvironment() == "TESTING" {
+		return nil
+	}
+
 	sender := os.Getenv("EMAIL_MAIL")
 	msg := gomail.NewMessage()
 	msg.SetHeader("From", sender)
@@ -23,5 +29,6 @@ func SendEmail(email string, subject string, validationCode string) error {
 		fmt.Println(err)
 		return err
 	}
+
 	return nil
 }

--- a/api/utils/helpers.go
+++ b/api/utils/helpers.go
@@ -26,7 +26,7 @@ next:
 				continue next
 			}
 		}
-		return fmt.Errorf("password must have at least one %s character", name)
+		return fmt.Errorf("Password must have at least one %s character", name)
 	}
 	return nil
 }


### PR DESCRIPTION
### Coverages 

| File                | Before | After |
| ------------------- | :----: | ----: |
| controllers/user.go | 17.6%  | 73.1% |

### How can I test the changes? 

1. Run the `go test ./...` command from the `api/` directory. 
2. (Optional 1) Run the `go test ./... -coverprofile=coverage.out` command from the `api/` directory.
3. (Optional 2) Run the `go tool cover --html=coverage.out` command from the `api/` directory to see the coverage HTML file. 
4. (Optional 3) Select the `users.go` file and you should see something like: 

![image](https://user-images.githubusercontent.com/62714297/230120189-96d962aa-811e-4b2a-a7f6-7bc86b96528a.png)
