### PR TITLE
Fix: Schemas

### DIFF
--- a/algorithms/database/models/mongoose.js
+++ b/algorithms/database/models/mongoose.js
@@ -24,6 +24,7 @@ ZoneSchema.index({ coordinates: "hashed" });
 const sharedRewardSchema = {
   type: [
     {
+      _id: false,
       reward_collection: {
         type: String,
         // Gym rewards can be items or loomballs

--- a/api/controllers/gyms.go
+++ b/api/controllers/gyms.go
@@ -121,6 +121,7 @@ func HandleClaimReward(c *gin.Context) {
 	for _, item := range items {
 		allRewards = append(allRewards, gin.H{
 			"id":       item.Id.Hex(),
+			"serial":   item.Serial,
 			"name":     item.Name,
 			"quantity": rewardsQuantity[item.Id.Hex()],
 		})
@@ -129,6 +130,7 @@ func HandleClaimReward(c *gin.Context) {
 	for _, loomball := range loomballs {
 		allRewards = append(allRewards, gin.H{
 			"id":       loomball.Id.Hex(),
+			"serial":   loomball.Serial,
 			"name":     loomball.Name,
 			"quantity": rewardsQuantity[loomball.Id.Hex()],
 		})


### PR DESCRIPTION
### Includes 

- [x] Remove the `_id` field from the gyms rewards (Closes #87).
- [x] Adding the `serial` field to items and loombals objects in `claim-reward` response 

### How can I test the changes

1. Re-generate the rewards running the `pnpm update:rewards` or `npm run updated:rewards` command from the `/algorithms/database` folder, both users and owners rewards should only have the `reward_collection`, `reward_id` and `reward_quantity` fields.
2. Test `/gyms/claim-reward` endpoint.