### PR TITLE
Feat: register battle changes

### DIFF
--- a/api/combat/MESSAGES_TYPES.md
+++ b/api/combat/MESSAGES_TYPES.md
@@ -12,7 +12,7 @@ The following are the supported messages types that are exchanged between the cl
 | `USER_DODGE`             | The user avoids the gym Loomie attack. Has a 1 second cooldown                                                        | Client | Server |
 | `GYM_ATTACK_DODGED`      | Confirmation that the user avoids the gym Loomie attack                                                               | Server | Client |
 | `USER_LOOMIE_WEAKENED`   | The user Loomie was defeated by the gym Loomie                                                                        | Server | Client |
-| `UPDATE_PLAYER_LOOMIE`   | The current user Loomie was changed                                                                                   | Server | Client |
+| `UPDATE_USER_LOOMIE`     | The current user Loomie was changed                                                                                   | Server | Client |
 | `UPDATE_USER_LOOMIE_HP`  | The current user Loomie was attacked by the gym Loomie                                                                | Server | Client |
 | `UPDATE_USER_LOOMIE_EXP` | The current user Loomie experience was updated                                                                        | Server | Client |
 | `USER_HAS_LOST`          | All the user Loomies were defeated                                                                                    | Server | Client |

--- a/api/combat/MESSAGES_TYPES.md
+++ b/api/combat/MESSAGES_TYPES.md
@@ -2,19 +2,20 @@
 
 The following are the supported messages types that are exchanged between the client and the server through the websocket.
 
-| Type                    | Description                                                                                                           | From   | To     |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------- | ------ | ------ |
-| `ERROR`                 | Unexpected server side error. You can find more information in the message description / payload                      | Server | Client |
-| `GYM_ATTACK_CANDIDATE`  | It announces an incoming attack. The user has the opportunity to dodge it using the `GYM_ATTACK_DODGED` message type. | Server | Client |
-| `USER_DODGE`            | The user avoids the gym Loomie attack. Has a 1 second cooldown                                                        | Client | Server |
-| `GYM_ATTACK_DODGED`     | Confirmation that the user avoids the gym Loomie attack                                                               | Server | Client |
-| `USER_LOOMIE_WEAKENED`  | The user Loomie was defeated by the gym Loomie                                                                        | Server | Client |
-| `UPDATE_PLAYER_LOOMIE`  | The current user Loomie was changed                                                                                   | Server | Client |
-| `UPDATE_USER_LOOMIE_HP` | The current user Loomie was attacked by the gym Loomie                                                                | Server | Client |
-| `USER_HAS_LOST`         | All the user Loomies were defeated                                                                                    | Server | Client |
-| `USER_ATTACK`           | It will reduce the gym Loomie hp. The enemy Loomie has a chance to dodge it (10%). Has a 1 second cooldown            | Client | Server |
-| `USER_ATTACK_DODGED`    | The gym avois the user Loomie attack                                                                                  | Server | Client |
-| `GYM_LOOMIE_WEAKENED`   | The gym Loomie was defeated by the user Loomie                                                                        | Server | Client |
-| `UPDATE_GYM_LOOMIE`     | The current gym Loomie was changed                                                                                    | Server | Client |
-| `UPDATE_GYM_LOOMIE_HP`  | The current gym Loomie was attacked by the user Loomie                                                                | Server | Client |
-| `USER_HAS_WON`          | All the gym Loomies were defeated                                                                                     | Server | Client |
+| Type                     | Description                                                                                                           | From   | To     |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------- | ------ | ------ |
+| `ERROR`                  | Unexpected server side error. You can find more information in the message description / payload                      | Server | Client |
+| `GYM_ATTACK_CANDIDATE`   | It announces an incoming attack. The user has the opportunity to dodge it using the `GYM_ATTACK_DODGED` message type. | Server | Client |
+| `USER_DODGE`             | The user avoids the gym Loomie attack. Has a 1 second cooldown                                                        | Client | Server |
+| `GYM_ATTACK_DODGED`      | Confirmation that the user avoids the gym Loomie attack                                                               | Server | Client |
+| `USER_LOOMIE_WEAKENED`   | The user Loomie was defeated by the gym Loomie                                                                        | Server | Client |
+| `UPDATE_PLAYER_LOOMIE`   | The current user Loomie was changed                                                                                   | Server | Client |
+| `UPDATE_USER_LOOMIE_HP`  | The current user Loomie was attacked by the gym Loomie                                                                | Server | Client |
+| `UPDATE_USER_LOOMIE_EXP` | The current user Loomie experience is updated Loomie                                                                  | Server | Client |
+| `USER_HAS_LOST`          | All the user Loomies were defeated                                                                                    | Server | Client |
+| `USER_ATTACK`            | It will reduce the gym Loomie hp. The enemy Loomie has a chance to dodge it (10%). Has a 1 second cooldown            | Client | Server |
+| `USER_ATTACK_DODGED`     | The gym avoid the user Loomie attack                                                                                  | Server | Client |
+| `GYM_LOOMIE_WEAKENED`    | The gym Loomie was defeated by the user Loomie                                                                        | Server | Client |
+| `UPDATE_GYM_LOOMIE`      | The current gym Loomie was changed                                                                                    | Server | Client |
+| `UPDATE_GYM_LOOMIE_HP`   | The current gym Loomie was attacked by the user Loomie                                                                | Server | Client |
+| `USER_HAS_WON`           | All the gym Loomies were defeated                                                                                     | Server | Client |

--- a/api/combat/handlers.go
+++ b/api/combat/handlers.go
@@ -301,7 +301,7 @@ func handlePlayerVictory(combat *WsCombat) {
 	}
 
 	// Updates the loomie team of the new owner with an empty array
-	err = models.ReplaceLoomieTeam(gymId, []primitive.ObjectID{})
+	err = models.ReplaceLoomieTeam(combat.PlayerID, []primitive.ObjectID{})
 	if err != nil {
 		combat.SendMessage(WsMessage{
 			Type:    "ERROR",

--- a/api/combat/handlers.go
+++ b/api/combat/handlers.go
@@ -98,7 +98,7 @@ func handleSendAttack(combat *WsCombat) {
 			combat.Close <- true
 			return
 		}
-    
+
 		for index := range combat.PlayerLoomies {
 			if combat.PlayerLoomies[index].BoostedHp > 0 {
 				// Update the current gym loomie

--- a/api/combat/handlers.go
+++ b/api/combat/handlers.go
@@ -109,7 +109,7 @@ func handleSendAttack(combat *WsCombat) {
 
 		// Notify the user that the current player loomie was changed
 		combat.SendMessage(WsMessage{
-			Type:    "UPDATE_PLAYER_LOOMIE",
+			Type:    "UPDATE_USER_LOOMIE",
 			Message: fmt.Sprintf("Your loomie %s is now your active loomie", combat.CurrentPlayerLoomie.Name),
 			Payload: map[string]interface{}{
 				"loomie": combat.CurrentPlayerLoomie,
@@ -269,6 +269,7 @@ func handleGymLoomieWeakened(combat *WsCombat, weakenedLoomieId primitive.Object
 			Message: fmt.Sprintf("Loomie %s received %.4f of experience", playerLoomiePointer.Name, experienceToSet),
 			Payload: map[string]interface{}{
 				"loomie": playerLoomiePointer.Id,
+				"exp":    playerLoomiePointer.Experience,
 			},
 		})
 
@@ -276,7 +277,7 @@ func handleGymLoomieWeakened(combat *WsCombat, weakenedLoomieId primitive.Object
 		if playerLoomiePointer.Level-preLevel != 0 {
 			updateStatsDuringWeakenedEvent(playerLoomiePointer)
 			combat.SendMessage(WsMessage{
-				Type:    "UPDATE_PLAYER_LOOMIE",
+				Type:    "UPDATE_USER_LOOMIE",
 				Message: fmt.Sprintf("Loomie %s received an update of hp, attack and defense", playerLoomiePointer.Name),
 				Payload: map[string]interface{}{
 					"loomie": playerLoomiePointer,
@@ -466,7 +467,7 @@ func handleUseItem(combat *WsCombat, message WsMessage) {
 
 	// Send the message to the user
 	combat.SendMessage(WsMessage{
-		Type:    "UPDATE_PLAYER_LOOMIE",
+		Type:    "UPDATE_USER_LOOMIE",
 		Message: fmt.Sprintf("Loomie: %s received the item: %s", combat.CurrentPlayerLoomie.Name, item.Name),
 		Payload: map[string]interface{}{
 			"loomie": combat.CurrentPlayerLoomie,
@@ -542,7 +543,7 @@ func handleChangeLoomie(combat *WsCombat, message WsMessage) {
 
 	// Send the message to the user
 	combat.SendMessage(WsMessage{
-		Type:    "UPDATE_PLAYER_LOOMIE",
+		Type:    "UPDATE_USER_LOOMIE",
 		Message: fmt.Sprintf("Loomie: %s is now the current player loomie", combat.CurrentPlayerLoomie.Name),
 		Payload: map[string]interface{}{
 			"loomie": combat.CurrentPlayerLoomie,

--- a/api/combat/handlers.go
+++ b/api/combat/handlers.go
@@ -205,78 +205,7 @@ func handleReceiveAttack(combat *WsCombat) {
 				Message: "You have won the battle. Now you own this gym",
 			})
 
-			gymId, _ := primitive.ObjectIDFromHex(combat.GymID)
-
-			gymInfo, err := models.GetPopulatedGymFromId(gymId, combat.PlayerID)
-
-			if err != nil {
-
-				combat.SendMessage(WsMessage{
-					Type:    "ERROR",
-					Message: "[INTERNAL SERVER ERROR] Error obtaining gym info",
-				})
-
-				return
-			}
-
-			// Updates the loomie team of the new owner
-			err = models.ReplaceLoomieTeam(gymId, []primitive.ObjectID{})
-			if err != nil {
-				combat.SendMessage(WsMessage{
-					Type:    "ERROR",
-					Message: "[INTERNAL SERVER ERROR] Error updating Loomie Team of user",
-				})
-			}
-
-			// Obtains ids of new protectors
-			newGymProtectors := []primitive.ObjectID{}
-			currentGymProtectors := []primitive.ObjectID{}
-
-			for _, playerLoomie := range combat.PlayerLoomies {
-				newGymProtectors = append(newGymProtectors, playerLoomie.Id)
-			}
-
-			for _, gymLoomie := range combat.GymLoomies {
-				currentGymProtectors = append(newGymProtectors, gymLoomie.Id)
-			}
-
-			if gymInfo.Owner != "" {
-				// Updates the gym old protectors
-				err = models.UpdateIsBusyStatusInCombat(currentGymProtectors, false)
-				if err != nil {
-					combat.SendMessage(WsMessage{
-						Type:    "ERROR",
-						Message: "[INTERNAL SERVER ERROR] Error updating current GymTeam is_busy field",
-					})
-				}
-			} else {
-				err = models.RemoveLoomieTeam(currentGymProtectors)
-				if err != nil {
-					combat.SendMessage(WsMessage{
-						Type:    "ERROR",
-						Message: "[INTERNAL SERVER ERROR] Error deleting current GymTeam",
-					})
-				}
-			}
-
-			// Updates the gym news protectors and owner
-			err = models.UpdateGymProtectorsAndOwner(gymId, newGymProtectors, combat.PlayerID)
-			if err != nil {
-				combat.SendMessage(WsMessage{
-					Type:    "ERROR",
-					Message: "[INTERNAL SERVER ERROR] Error updating Loomie Team of user and its owner",
-				})
-			}
-			// Updates the gym news protectors, is_busy propierties
-			err = models.UpdateIsBusyStatusInCombat(newGymProtectors, true)
-			if err != nil {
-				combat.SendMessage(WsMessage{
-					Type:    "ERROR",
-					Message: "[INTERNAL SERVER ERROR] Error updating Loomie Team is_busy field",
-				})
-			}
-
-			combat.Close <- true
+			handlePlayerVictory(combat)
 			return
 		}
 
@@ -315,8 +244,6 @@ func handleReceiveAttack(combat *WsCombat) {
 
 // handleGymLoomieWeakened handles the "event" when a gym loomie is weakened by the player to add experience to the player loomies that fought the gym loomie
 func handleGymLoomieWeakened(combat *WsCombat, weakenedLoomieId primitive.ObjectID, levelWeakenedLoomieId int) {
-
-	//fmt.Println("Handling Gym Loomie Weakened Event for:", weakenedLoomieId)
 	// Obtains Loomies who weakened the enemy Loomie
 	foughtWith := combat.FoughtGymLoomies[weakenedLoomieId]
 
@@ -335,7 +262,7 @@ func handleGymLoomieWeakened(combat *WsCombat, weakenedLoomieId primitive.Object
 		playerLoomiePointer.Experience, playerLoomiePointer.Level = calculateLevelAndExperience(playerLoomiePointer.Experience, experienceToSet, playerLoomiePointer.Level)
 
 		// updates and sets new exp and lvl in db
-		models.UpdateExperienceAndLevelInCombat(combat.PlayerID, playerLoomiePointer)
+		models.UpdateLoomiesExpAndLvl(combat.PlayerID, playerLoomiePointer)
 
 		combat.SendMessage(WsMessage{
 			Type:    "UPDATE_USER_LOOMIE_EXP",
@@ -357,8 +284,82 @@ func handleGymLoomieWeakened(combat *WsCombat, weakenedLoomieId primitive.Object
 			})
 		}
 	}
+}
 
-	//fmt.Println("Weakened Event Handled")
+// handlePlayerVictory handles the "event" when the player wins the battle
+func handlePlayerVictory(combat *WsCombat) {
+	gymId, _ := primitive.ObjectIDFromHex(combat.GymID)
+	gymInfo, err := models.GetPopulatedGymFromId(gymId, combat.PlayerID)
+
+	if err != nil {
+		combat.SendMessage(WsMessage{
+			Type:    "ERROR",
+			Message: "[INTERNAL SERVER ERROR] Error obtaining gym info",
+		})
+
+		return
+	}
+
+	// Updates the loomie team of the new owner with an empty array
+	err = models.ReplaceLoomieTeam(gymId, []primitive.ObjectID{})
+	if err != nil {
+		combat.SendMessage(WsMessage{
+			Type:    "ERROR",
+			Message: "[INTERNAL SERVER ERROR] Error updating Loomie Team of user",
+		})
+	}
+
+	// Obtains ids of new protectors
+	newGymProtectors := []primitive.ObjectID{}
+	currentGymProtectors := []primitive.ObjectID{}
+
+	for _, playerLoomie := range combat.PlayerLoomies {
+		newGymProtectors = append(newGymProtectors, playerLoomie.Id)
+	}
+
+	for _, gymLoomie := range combat.GymLoomies {
+		currentGymProtectors = append(newGymProtectors, gymLoomie.Id)
+	}
+
+	if gymInfo.Owner != "" {
+		// Updates the gym old protectors
+		err = models.UpdateLoomiesBusyState(currentGymProtectors, false)
+		if err != nil {
+			combat.SendMessage(WsMessage{
+				Type:    "ERROR",
+				Message: "[INTERNAL SERVER ERROR] Error updating current gym protectors status",
+			})
+		}
+	} else {
+		// Removes the gym old protectors
+		err = models.RemoveLoomieTeam(currentGymProtectors)
+		if err != nil {
+			combat.SendMessage(WsMessage{
+				Type:    "ERROR",
+				Message: "[INTERNAL SERVER ERROR] Error deleting current gym protectors",
+			})
+		}
+	}
+
+	// Updates the gym news protectors and owner
+	err = models.UpdateGymProtectorsAndOwner(gymId, newGymProtectors, combat.PlayerID)
+	if err != nil {
+		combat.SendMessage(WsMessage{
+			Type:    "ERROR",
+			Message: "[INTERNAL SERVER ERROR] Error updating Loomie Team of user and its owner",
+		})
+	}
+
+	// Updates the gym news protectors, is_busy propierties
+	err = models.UpdateLoomiesBusyState(newGymProtectors, true)
+	if err != nil {
+		combat.SendMessage(WsMessage{
+			Type:    "ERROR",
+			Message: "[INTERNAL SERVER ERROR] Error updating Loomie Team is_busy field",
+		})
+	}
+
+	combat.Close <- true
 }
 
 // handleUseItem handles the use of an item by the player

--- a/api/combat/handlers.go
+++ b/api/combat/handlers.go
@@ -252,8 +252,8 @@ func handleGymLoomieWeakened(combat *WsCombat, weakenedLoomieId primitive.Object
 	experienceToSet := (expWeakenedLoomieId / 3) / float64(len(foughtWith))
 
 	// adds the experience to each Loomie in foughtWith
-	for _, playerLoomiePointer := range foughtWith {
-		//fmt.Println("Adding experience to player loomie:", playerLoomiePointer)
+	for index := range foughtWith {
+		playerLoomiePointer := foughtWith[index]
 
 		// usefull if the loomie level up
 		preLevel := playerLoomiePointer.Level
@@ -318,7 +318,7 @@ func handlePlayerVictory(combat *WsCombat) {
 	}
 
 	for _, gymLoomie := range combat.GymLoomies {
-		currentGymProtectors = append(newGymProtectors, gymLoomie.Id)
+		currentGymProtectors = append(currentGymProtectors, gymLoomie.Id)
 	}
 
 	if gymInfo.Owner != "" {

--- a/api/combat/helpers.go
+++ b/api/combat/helpers.go
@@ -131,7 +131,6 @@ func applyItem(userId primitive.ObjectID, item *interfaces.PopulatedInventoryIte
 // TODO generalize?
 // calculateLevelAndExperience calculates what is lvl and experience of a Loomie that weakened another one
 func calculateLevelAndExperience(loomieExperience float64, availableExperience float64, loomieLevel int) (float64, int) {
-
 	var experienceToAdd, neededExperienceToNextLevel float64
 
 	// Check if the loomie has leveled up

--- a/api/combat/helpers.go
+++ b/api/combat/helpers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/PedroChaparro/loomies-backend/interfaces"
 	"github.com/PedroChaparro/loomies-backend/models"
+	"github.com/PedroChaparro/loomies-backend/utils"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -125,4 +126,55 @@ func applyItem(userId primitive.ObjectID, item *interfaces.PopulatedInventoryIte
 	}
 
 	return nil
+}
+
+// TODO generalize?
+// calculateLevelAndExperience calculates what is lvl and experience of a Loomie that weakened another one
+func calculateLevelAndExperience(loomieExperience float64, availableExperience float64, loomieLevel int) (float64, int) {
+
+	var experienceToAdd, neededExperienceToNextLevel float64
+
+	// Check if the loomie has leveled up
+	for (loomieExperience + availableExperience) >= utils.GetRequiredExperience(loomieLevel+1) {
+		neededExperienceToNextLevel = utils.GetRequiredExperience(loomieLevel+1) - loomieExperience
+		experienceToAdd = math.Min(availableExperience, neededExperienceToNextLevel)
+		experienceToAdd = utils.FixeFloat(experienceToAdd, 4)
+		loomieLevel++
+		loomieExperience = 0
+		availableExperience -= experienceToAdd
+	}
+
+	loomieExperience += availableExperience
+
+	resultExp := utils.FixeFloat(loomieExperience, 4)
+	return resultExp, loomieLevel
+}
+
+// UpdateStatsDuringWeakenedEvent updates maxhp, hp, attack and defense if a loomie advance in lvl during a weakened event
+func updateStatsDuringWeakenedEvent(loomieToUpdate *interfaces.CombatLoomie) {
+	// Tracking previous boosts in MaxHP, Attack, Defense
+	initialMaxHp := calulateExperienceFactorStats(loomieToUpdate.BaseHp, loomieToUpdate.Level-1)
+	previousMaxHpBoosts := loomieToUpdate.MaxHp - initialMaxHp
+
+	initialBoostedAttack := calulateExperienceFactorStats(loomieToUpdate.BaseAttack, loomieToUpdate.Level-1)
+	previousAttackBoosts := loomieToUpdate.BoostedAttack - initialBoostedAttack
+
+	initialBoostedDefense := calulateExperienceFactorStats(loomieToUpdate.BaseDefense, loomieToUpdate.Level-1)
+	previousDefenseBoosts := loomieToUpdate.BoostedDefense - initialBoostedDefense
+
+	// Update previous boosts in MaxHP, Attack, Defense
+	loomieToUpdate.MaxHp = calulateExperienceFactorStats(loomieToUpdate.BaseHp, loomieToUpdate.Level) + previousMaxHpBoosts
+	loomieToUpdate.BoostedAttack = calulateExperienceFactorStats(loomieToUpdate.BaseAttack, loomieToUpdate.Level) + previousAttackBoosts
+	loomieToUpdate.BaseDefense = calulateExperienceFactorStats(loomieToUpdate.BaseDefense, loomieToUpdate.Level) + previousDefenseBoosts
+
+	// Here the new level boost (+1/8 of the base hp) is incremented
+	possibleHpIncrement := int(math.Floor(float64(loomieToUpdate.BaseHp)) * (1.0 / 8.0))
+	possibleBoostedHp := float64(loomieToUpdate.BoostedHp) + float64(possibleHpIncrement)
+	loomieToUpdate.BoostedHp = int(math.Min(possibleBoostedHp, float64(loomieToUpdate.MaxHp)))
+}
+
+// CalulateExperienceFactorStats helper of updateStatsDuringWeakenedEvent
+func calulateExperienceFactorStats(baseStat int, level int) int {
+	experienceFactor := (1.0 + ((1.0 / 8.0) * (float64(level) - 1.0)))
+	return int(math.Floor(float64(baseStat) * experienceFactor))
 }

--- a/api/models/gyms.go
+++ b/api/models/gyms.go
@@ -92,7 +92,6 @@ func GetPopulatedGymFromId(GymId, UserId primitive.ObjectID) (gym interfaces.Pop
 
 // UpdateGymProtectors Updates Gym Protectors (the loomies team of the owner) and new owner
 func UpdateGymProtectorsAndOwner(GymId primitive.ObjectID, loomiesProtectorsIds []primitive.ObjectID, newOwner primitive.ObjectID) (err error) {
-
 	_, err = GymsCollection.UpdateOne(
 		context.TODO(),
 		bson.D{{Key: "_id", Value: GymId}},

--- a/api/models/gyms.go
+++ b/api/models/gyms.go
@@ -89,3 +89,20 @@ func GetPopulatedGymFromId(GymId, UserId primitive.ObjectID) (gym interfaces.Pop
 	GymDoc.WasRewardClaimed = HasUserClaimedReward(auxiliarGymDoc.RewardsClaimedBy, UserId)
 	return GymDoc, nil
 }
+
+// UpdateGymProtectors Updates Gym Protectors (the loomies team of the owner) and new owner
+func UpdateGymProtectorsAndOwner(GymId primitive.ObjectID, loomiesProtectorsIds []primitive.ObjectID, newOwner primitive.ObjectID) (err error) {
+
+	_, err = GymsCollection.UpdateOne(
+		context.TODO(),
+		bson.D{{Key: "_id", Value: GymId}},
+		bson.D{
+			{Key: "$set", Value: bson.D{
+				{Key: "protectors", Value: loomiesProtectorsIds},
+				{Key: "owner", Value: newOwner},
+			}},
+		},
+	)
+
+	return err
+}

--- a/api/models/loomies.go
+++ b/api/models/loomies.go
@@ -323,7 +323,6 @@ func IncrementLoomieLevel(userId primitive.ObjectID, loomieId primitive.ObjectID
 	return nil
 }
 
-// TODO check if everything works
 // UpdateLoomieExperienceAndLevel Allows to uptade experience and level of a loomie after weakened a loomie
 func UpdateExperienceAndLevelInCombat(userId primitive.ObjectID, loomieToUpdate *interfaces.CombatLoomie) error {
 	// Update the first loomie in the caught loomies collection
@@ -345,6 +344,29 @@ func UpdateExperienceAndLevelInCombat(userId primitive.ObjectID, loomieToUpdate 
 	}
 
 	return nil
+}
+
+// UpdateIsBusyStatusInCombat Allows to uptade is_busy field of a looser o winner team of loomies (depends of the flag)
+func UpdateIsBusyStatusInCombat(loomiesProtectorsIds []primitive.ObjectID, flag bool) (err error) {
+
+	_, err = CaughtLoomiesCollection.UpdateMany(
+		context.TODO(),
+		bson.M{"_id": bson.M{"$in": loomiesProtectorsIds}},
+		bson.D{{Key: "$set", Value: bson.D{
+			{Key: "is_busy", Value: flag},
+		}}},
+	)
+
+	return err
+}
+
+// RemoveLoomieTeam Removes Loomie Team just when the gym doesnt have owner
+func RemoveLoomieTeam(loomiesProtectorsIds []primitive.ObjectID) (err error) {
+	_, err = CaughtLoomiesCollection.DeleteMany(
+		context.TODO(),
+		bson.M{"_id": bson.M{"$in": loomiesProtectorsIds}},
+	)
+	return err
 }
 
 // GetLoomieTypeDetails Returns the details of a loomie type

--- a/api/models/loomies.go
+++ b/api/models/loomies.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/PedroChaparro/loomies-backend/configuration"
@@ -317,6 +318,30 @@ func IncrementLoomieLevel(userId primitive.ObjectID, loomieId primitive.ObjectID
 	// Check errors
 	if result.Err() != nil {
 		return result.Err()
+	}
+
+	return nil
+}
+
+// TODO check if everything works
+// UpdateLoomieExperienceAndLevel Allows to uptade experience and level of a loomie after weakened a loomie
+func UpdateExperienceAndLevelInCombat(userId primitive.ObjectID, loomieToUpdate *interfaces.CombatLoomie) error {
+	// Update the first loomie in the caught loomies collection
+	_, err := CaughtLoomiesCollection.UpdateOne(
+		context.TODO(),
+		bson.D{
+			{Key: "_id", Value: loomieToUpdate.Id},
+		},
+		bson.D{
+			{Key: "$set", Value: bson.D{
+				{Key: "experience", Value: loomieToUpdate.Experience},
+				{Key: "level", Value: loomieToUpdate.Level},
+			}},
+		},
+	)
+
+	if err != nil {
+		return errors.New("Error")
 	}
 
 	return nil

--- a/api/models/loomies.go
+++ b/api/models/loomies.go
@@ -340,8 +340,8 @@ func IncrementLoomieLevel(userId primitive.ObjectID, loomieId primitive.ObjectID
 	return nil
 }
 
-// UpdateLoomieExperienceAndLevel Allows to uptade experience and level of a loomie after weakened a loomie
-func UpdateExperienceAndLevelInCombat(userId primitive.ObjectID, loomieToUpdate *interfaces.CombatLoomie) error {
+// UpdateLoomiesExpAndLvl Allows to uptade experience and level of a loomie after weakened a loomie
+func UpdateLoomiesExpAndLvl(userId primitive.ObjectID, loomieToUpdate *interfaces.CombatLoomie) error {
 	// Update the first loomie in the caught loomies collection
 	_, err := CaughtLoomiesCollection.UpdateOne(
 		context.TODO(),
@@ -363,9 +363,8 @@ func UpdateExperienceAndLevelInCombat(userId primitive.ObjectID, loomieToUpdate 
 	return nil
 }
 
-// UpdateIsBusyStatusInCombat Allows to uptade is_busy field of a looser o winner team of loomies (depends of the flag)
-func UpdateIsBusyStatusInCombat(loomiesProtectorsIds []primitive.ObjectID, flag bool) (err error) {
-
+// UpdateLoomiesBusyState Allows to uptade is_busy field of a looser o winner team of loomies (depends of the flag)
+func UpdateLoomiesBusyState(loomiesProtectorsIds []primitive.ObjectID, flag bool) (err error) {
 	_, err = CaughtLoomiesCollection.UpdateMany(
 		context.TODO(),
 		bson.M{"_id": bson.M{"$in": loomiesProtectorsIds}},


### PR DESCRIPTION
What includes?

- updates experiencie of user according with the level during combat
- updates attack, defense, hp, maxHp during combat
- updates owner and gyms protectors

How can I test this?

- Reach level change, to test experience upgrade, attack, defense, hp
- Attack an enemy with different loomies
- Win a fight against a gym with an owner and without an owner