### PR TITLE
Fix: Websocket send message as JSON instead of string

### DIFF
--- a/api/combat/interfaces.go
+++ b/api/combat/interfaces.go
@@ -99,9 +99,7 @@ func (combat *WsCombat) UpdatedLastUserAttackTimestamp() {
 
 // SendMessage sends a message to the client
 func (combat *WsCombat) SendMessage(message WsMessage) {
-	jsonMessage, _ := json.Marshal(message)
-	stringJson := string(jsonMessage)
-	combat.Connection.WriteJSON(stringJson)
+	combat.Connection.WriteJSON(message)
 }
 
 // Listen is the function that listens for messages from the client


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/61242172/233884244-bd71f43c-f046-41f8-b74c-9abab421e06f.png)


After:
![image](https://user-images.githubusercontent.com/61242172/233884274-c33a6152-6f1b-4913-a40e-f7dc7cb3112c.png)
